### PR TITLE
Add PQRRS monthly reporting page with CSV export

### DIFF
--- a/wp-content/plugins/eeppj-pqrrs/assets/css/pqrrs-admin.css
+++ b/wp-content/plugins/eeppj-pqrrs/assets/css/pqrrs-admin.css
@@ -467,3 +467,68 @@
   color: var(--pq-text-tertiary) !important;
   padding: 2rem !important;
 }
+
+/* ==========================================================================
+   Reports — date controls, numeric cells, back link
+   ========================================================================== */
+.eeppj-report-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin: 1.25rem 0 1.5rem;
+  flex-wrap: wrap;
+}
+
+.eeppj-report-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: var(--pq-font-body);
+}
+
+.eeppj-report-controls input[type="month"] {
+  font-family: var(--pq-font-mono);
+  font-size: 0.8125rem;
+  padding: 6px 10px;
+  border: 1px solid var(--pq-border);
+  border-radius: var(--pq-radius-md);
+  background: var(--pq-surface);
+  color: var(--pq-text-primary);
+  line-height: 1.4;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.eeppj-report-controls input[type="month"]:focus {
+  outline: none;
+  border-color: var(--pq-accent);
+  box-shadow: 0 0 0 2px rgba(30, 75, 117, 0.1);
+}
+
+.eeppj-num {
+  font-family: var(--pq-font-mono);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.eeppj-num-zero {
+  font-family: var(--pq-font-mono);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--pq-text-tertiary);
+}
+
+.eeppj-back-link {
+  display: inline-block;
+  font-family: var(--pq-font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--pq-text-secondary);
+  text-decoration: none;
+  margin-bottom: 0.5rem;
+  padding: 4px 0;
+  transition: color 0.12s ease;
+}
+
+.eeppj-back-link:hover {
+  color: var(--pq-accent);
+}

--- a/wp-content/plugins/eeppj-pqrrs/eeppj-pqrrs.php
+++ b/wp-content/plugins/eeppj-pqrrs/eeppj-pqrrs.php
@@ -24,6 +24,7 @@ require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-handler.php';
 require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-form.php';
 require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-admin.php';
 require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-email.php';
+require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-reports.php';
 
 /* ====== Activation: create DB table ====== */
 function eeppj_pqrrs_activate() {
@@ -95,6 +96,7 @@ function eeppj_pqrrs_init() {
     EEPPJ_PQRRS_Form::init();
     EEPPJ_PQRRS_Handler::init();
     EEPPJ_PQRRS_Admin::init();
+    EEPPJ_PQRRS_Reports::init();
 }
 add_action('init', 'eeppj_pqrrs_init');
 

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
@@ -1,0 +1,490 @@
+<?php
+/**
+ * PQRRS Reports — monthly summary + detail views with CSV export
+ *
+ * @package eeppj-pqrrs
+ */
+
+defined('ABSPATH') || exit;
+
+class EEPPJ_PQRRS_Reports {
+
+    private static $statuses = [
+        'pendiente'   => ['label' => 'Pendiente',   'color' => '#d97706', 'bg' => '#fffbeb'],
+        'en_progreso' => ['label' => 'En Progreso',  'color' => '#2563eb', 'bg' => '#eff6ff'],
+        'completada'  => ['label' => 'Completada',   'color' => '#16a34a', 'bg' => '#f0fdf4'],
+        'descartada'  => ['label' => 'Descartada',   'color' => '#6b7280', 'bg' => '#f3f4f6'],
+    ];
+
+    private static $tipos = ['peticion', 'queja', 'reclamo', 'recurso', 'sugerencia'];
+
+    private static $tipo_labels = [
+        'peticion' => 'Peticiones', 'queja' => 'Quejas', 'reclamo' => 'Reclamos',
+        'recurso' => 'Recursos', 'sugerencia' => 'Sugerencias',
+    ];
+
+    private static $tipo_colors = [
+        'peticion' => '#3182ce', 'queja' => '#e53e3e', 'reclamo' => '#dd6b20',
+        'recurso' => '#805ad5', 'sugerencia' => '#38a169',
+    ];
+
+    private static $month_names = [
+        1 => 'Enero', 2 => 'Febrero', 3 => 'Marzo', 4 => 'Abril',
+        5 => 'Mayo', 6 => 'Junio', 7 => 'Julio', 8 => 'Agosto',
+        9 => 'Septiembre', 10 => 'Octubre', 11 => 'Noviembre', 12 => 'Diciembre',
+    ];
+
+    public static function init() {
+        add_action('admin_menu', [__CLASS__, 'add_submenu']);
+        add_action('admin_post_eeppj_pqrrs_csv', [__CLASS__, 'handle_csv_export']);
+    }
+
+    public static function add_submenu() {
+        add_submenu_page(
+            'eeppj-pqrrs', 'Reportes PQRRS', 'Reportes', 'manage_options',
+            'eeppj-pqrrs-reports', [__CLASS__, 'render_reports']
+        );
+    }
+
+    public static function render_reports() {
+        if (!current_user_can('manage_options')) return;
+
+        $mes = sanitize_text_field($_GET['mes'] ?? '');
+        if ($mes && preg_match('/^\d{4}-\d{2}$/', $mes)) {
+            self::render_month_detail($mes);
+        } else {
+            self::render_summary();
+        }
+    }
+
+    private static function get_month_name($year_month) {
+        $parts = explode('-', $year_month);
+        $m = (int) $parts[1];
+        $y = $parts[0];
+        return (self::$month_names[$m] ?? $m) . ' ' . $y;
+    }
+
+    private static function render_summary() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'eeppj_pqrrs';
+
+        // Default range: last 12 months
+        $default_hasta = date('Y-m');
+        $default_desde = date('Y-m', strtotime('-11 months'));
+
+        $desde = sanitize_text_field($_GET['desde'] ?? $default_desde);
+        $hasta = sanitize_text_field($_GET['hasta'] ?? $default_hasta);
+
+        // Validate format
+        if (!preg_match('/^\d{4}-\d{2}$/', $desde)) $desde = $default_desde;
+        if (!preg_match('/^\d{4}-\d{2}$/', $hasta)) $hasta = $default_hasta;
+
+        $date_start = $desde . '-01';
+        // End of "hasta" month: first day of next month
+        $date_end = date('Y-m-01', strtotime($hasta . '-01 +1 month'));
+
+        // Query grouped by month + tipo
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT DATE_FORMAT(created_at, '%%Y-%%m') AS mes, tipo, COUNT(*) AS total
+             FROM $table
+             WHERE created_at >= %s AND created_at < %s
+             GROUP BY mes, tipo
+             ORDER BY mes DESC",
+            $date_start, $date_end
+        ));
+
+        // Build lookup: $data[month][tipo] = count
+        $data = [];
+        foreach ($rows as $r) {
+            $data[$r->mes][$r->tipo] = (int) $r->total;
+        }
+
+        // Enumerate all months in range (fill gaps)
+        $all_months = [];
+        $cursor = new DateTime($hasta . '-01');
+        $limit = new DateTime($desde . '-01');
+        while ($cursor >= $limit) {
+            $all_months[] = $cursor->format('Y-m');
+            $cursor->modify('-1 month');
+        }
+
+        // Stat cards: totals across the entire range
+        $grand_total = 0;
+        $tipo_totals = array_fill_keys(self::$tipos, 0);
+        foreach ($data as $month_data) {
+            foreach (self::$tipos as $t) {
+                $cnt = isset($month_data[$t]) ? $month_data[$t] : 0;
+                $tipo_totals[$t] += $cnt;
+                $grand_total += $cnt;
+            }
+        }
+
+        $csv_url = wp_nonce_url(
+            admin_url('admin-post.php?action=eeppj_pqrrs_csv&mode=summary&desde=' . $desde . '&hasta=' . $hasta),
+            'eeppj_pqrrs_csv'
+        );
+        ?>
+        <div class="wrap eeppj-admin">
+          <h1>Reportes PQRRS</h1>
+
+          <!-- Date range controls -->
+          <form method="get" class="eeppj-report-controls">
+            <input type="hidden" name="page" value="eeppj-pqrrs-reports" />
+            <label>
+              <span style="font-size:0.75rem;font-weight:600;color:#57606a;">Desde</span>
+              <input type="month" name="desde" value="<?php echo esc_attr($desde); ?>" />
+            </label>
+            <label>
+              <span style="font-size:0.75rem;font-weight:600;color:#57606a;">Hasta</span>
+              <input type="month" name="hasta" value="<?php echo esc_attr($hasta); ?>" />
+            </label>
+            <button type="submit" class="button button-primary" style="align-self:flex-end;">Consultar</button>
+            <a href="<?php echo esc_url($csv_url); ?>" class="button" style="align-self:flex-end;">Exportar CSV</a>
+          </form>
+
+          <!-- Stat cards -->
+          <div class="eeppj-stats">
+            <div class="eeppj-stat-card">
+              <div class="eeppj-stat-number"><?php echo esc_html($grand_total); ?></div>
+              <div class="eeppj-stat-label">Total</div>
+            </div>
+            <?php foreach (self::$tipos as $t) : ?>
+              <div class="eeppj-stat-card" style="border-top: 3px solid <?php echo esc_attr(self::$tipo_colors[$t]); ?>;">
+                <div class="eeppj-stat-number" style="color: <?php echo esc_attr(self::$tipo_colors[$t]); ?>;"><?php echo esc_html($tipo_totals[$t]); ?></div>
+                <div class="eeppj-stat-label"><?php echo esc_html(self::$tipo_labels[$t]); ?></div>
+              </div>
+            <?php endforeach; ?>
+          </div>
+
+          <!-- Summary table -->
+          <table class="wp-list-table widefat fixed striped">
+            <thead>
+              <tr>
+                <th>Mes</th>
+                <?php foreach (self::$tipos as $t) : ?>
+                  <th style="width:100px;text-align:right;"><?php echo esc_html(self::$tipo_labels[$t]); ?></th>
+                <?php endforeach; ?>
+                <th style="width:80px;text-align:right;">Total</th>
+                <th style="width:100px;"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($all_months as $ym) :
+                  $month_data = isset($data[$ym]) ? $data[$ym] : [];
+                  $row_total = 0;
+              ?>
+                <tr>
+                  <td><strong><?php echo esc_html(self::get_month_name($ym)); ?></strong></td>
+                  <?php foreach (self::$tipos as $t) :
+                      $cnt = isset($month_data[$t]) ? $month_data[$t] : 0;
+                      $row_total += $cnt;
+                  ?>
+                    <td class="<?php echo $cnt === 0 ? 'eeppj-num-zero' : 'eeppj-num'; ?>" style="text-align:right;">
+                      <?php echo esc_html($cnt); ?>
+                    </td>
+                  <?php endforeach; ?>
+                  <td class="eeppj-num" style="text-align:right;font-weight:600;"><?php echo esc_html($row_total); ?></td>
+                  <td>
+                    <a href="<?php echo esc_url(admin_url('admin.php?page=eeppj-pqrrs-reports&mes=' . $ym)); ?>" class="button button-small">
+                      Ver detalle
+                    </a>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+        <?php
+    }
+
+    private static function render_month_detail($mes) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'eeppj_pqrrs';
+
+        $date_start = $mes . '-01';
+        $date_end = date('Y-m-01', strtotime($date_start . ' +1 month'));
+
+        // Filters
+        $filter_tipo = sanitize_text_field($_GET['tipo'] ?? '');
+        $filter_status = sanitize_text_field($_GET['status'] ?? '');
+
+        $page = max(1, (int) ($_GET['paged'] ?? 1));
+        $per_page = 20;
+        $offset = ($page - 1) * $per_page;
+
+        // Stats for the month (unfiltered)
+        $total = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*) FROM $table WHERE created_at >= %s AND created_at < %s",
+            $date_start, $date_end
+        ));
+        $status_counts = $wpdb->get_results($wpdb->prepare(
+            "SELECT status, COUNT(*) as cnt FROM $table WHERE created_at >= %s AND created_at < %s GROUP BY status",
+            $date_start, $date_end
+        ), OBJECT_K);
+
+        // Build WHERE for filtered list
+        $where_parts = [
+            $wpdb->prepare("created_at >= %s", $date_start),
+            $wpdb->prepare("created_at < %s", $date_end),
+        ];
+        if ($filter_tipo && in_array($filter_tipo, self::$tipos, true)) {
+            $where_parts[] = $wpdb->prepare("tipo = %s", $filter_tipo);
+        }
+        if ($filter_status && isset(self::$statuses[$filter_status])) {
+            $where_parts[] = $wpdb->prepare("status = %s", $filter_status);
+        }
+        $where = 'WHERE ' . implode(' AND ', $where_parts);
+
+        $submissions = $wpdb->get_results(
+            "SELECT * FROM $table $where ORDER BY created_at DESC LIMIT $per_page OFFSET $offset"
+        );
+        $total_filtered = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table $where");
+        $total_pages = (int) ceil($total_filtered / $per_page);
+
+        $base_url = admin_url('admin.php?page=eeppj-pqrrs-reports&mes=' . $mes);
+        $csv_url = wp_nonce_url(
+            admin_url('admin-post.php?action=eeppj_pqrrs_csv&mode=detail&mes=' . $mes),
+            'eeppj_pqrrs_csv'
+        );
+        ?>
+        <div class="wrap eeppj-admin">
+          <a href="<?php echo esc_url(admin_url('admin.php?page=eeppj-pqrrs-reports')); ?>" class="eeppj-back-link">&larr; Volver a reportes</a>
+          <h1>Reporte: <?php echo esc_html(self::get_month_name($mes)); ?></h1>
+
+          <!-- Stat cards: total + per-status -->
+          <div class="eeppj-stats">
+            <div class="eeppj-stat-card">
+              <div class="eeppj-stat-number"><?php echo esc_html($total); ?></div>
+              <div class="eeppj-stat-label">Total</div>
+            </div>
+            <?php foreach (self::$statuses as $skey => $sinfo) :
+                $cnt = isset($status_counts[$skey]) ? (int) $status_counts[$skey]->cnt : 0;
+            ?>
+              <div class="eeppj-stat-card" style="border-top: 3px solid <?php echo esc_attr($sinfo['color']); ?>;">
+                <div class="eeppj-stat-number" style="color: <?php echo esc_attr($sinfo['color']); ?>;"><?php echo esc_html($cnt); ?></div>
+                <div class="eeppj-stat-label"><?php echo esc_html($sinfo['label']); ?></div>
+              </div>
+            <?php endforeach; ?>
+          </div>
+
+          <!-- Filters -->
+          <div class="eeppj-filter-group">
+            <div class="eeppj-filter" style="margin-bottom: 0.5rem;">
+              <strong style="font-size: 0.75rem; color: #6b7280; margin-right: 0.25rem;">Tipo:</strong>
+              <a href="<?php echo esc_url(add_query_arg('tipo', '', remove_query_arg('paged', $base_url . ($filter_status ? '&status=' . $filter_status : '')))); ?>"
+                 class="<?php echo $filter_tipo ? '' : 'active'; ?>">Todos</a>
+              <?php foreach (self::$tipos as $t) : ?>
+                <a href="<?php echo esc_url(add_query_arg('tipo', $t, remove_query_arg('paged', $base_url . ($filter_status ? '&status=' . $filter_status : '')))); ?>"
+                   class="<?php echo $filter_tipo === $t ? 'active' : ''; ?>"
+                   style="--badge-color: <?php echo esc_attr(self::$tipo_colors[$t]); ?>;">
+                  <?php echo esc_html(self::$tipo_labels[$t]); ?>
+                </a>
+              <?php endforeach; ?>
+            </div>
+            <div class="eeppj-filter">
+              <strong style="font-size: 0.75rem; color: #6b7280; margin-right: 0.25rem;">Estado:</strong>
+              <a href="<?php echo esc_url(add_query_arg('status', '', remove_query_arg('paged', $base_url . ($filter_tipo ? '&tipo=' . $filter_tipo : '')))); ?>"
+                 class="<?php echo $filter_status ? '' : 'active'; ?>">Todos</a>
+              <?php foreach (self::$statuses as $skey => $sinfo) : ?>
+                <a href="<?php echo esc_url(add_query_arg('status', $skey, remove_query_arg('paged', $base_url . ($filter_tipo ? '&tipo=' . $filter_tipo : '')))); ?>"
+                   class="<?php echo $filter_status === $skey ? 'active' : ''; ?>"
+                   style="--badge-color: <?php echo esc_attr($sinfo['color']); ?>;">
+                  <?php echo esc_html($sinfo['label']); ?>
+                </a>
+              <?php endforeach; ?>
+            </div>
+          </div>
+
+          <div style="margin-bottom:1rem;">
+            <a href="<?php echo esc_url($csv_url); ?>" class="button">Exportar CSV</a>
+          </div>
+
+          <!-- Submissions table (read-only) -->
+          <table class="wp-list-table widefat fixed striped">
+            <thead>
+              <tr>
+                <th style="width:84px;">Radicado</th>
+                <th style="width:90px;">Tipo</th>
+                <th style="width:150px;">Nombre</th>
+                <th style="width:180px;">Email</th>
+                <th>Asunto</th>
+                <th style="width:100px;">Estado</th>
+                <th style="width:130px;">Fecha</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php if (empty($submissions)) : ?>
+                <tr><td colspan="7" style="text-align:center;color:#666;">No hay solicitudes en este período.</td></tr>
+              <?php endif; ?>
+              <?php foreach ($submissions as $s) :
+                  $st = self::$statuses[$s->status] ?? self::$statuses['pendiente'];
+              ?>
+                <tr>
+                  <td><code><?php echo esc_html($s->submission_id); ?></code></td>
+                  <td>
+                    <span class="eeppj-badge" style="background: <?php echo esc_attr(self::$tipo_colors[$s->tipo] ?? '#666'); ?>;">
+                      <?php echo esc_html(ucfirst($s->tipo)); ?>
+                    </span>
+                  </td>
+                  <td><?php echo esc_html($s->nombre); ?></td>
+                  <td><?php echo esc_html($s->email); ?></td>
+                  <td><?php echo esc_html(wp_trim_words($s->asunto, 8)); ?></td>
+                  <td>
+                    <span class="eeppj-status-badge" style="color:<?php echo esc_attr($st['color']); ?>;background:<?php echo esc_attr($st['bg']); ?>;">
+                      <?php echo esc_html($st['label']); ?>
+                    </span>
+                  </td>
+                  <td><?php echo esc_html(wp_date('d/m/Y H:i', strtotime($s->created_at))); ?></td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+
+          <?php if ($total_pages > 1) : ?>
+            <div class="tablenav bottom">
+              <div class="tablenav-pages">
+                <?php for ($i = 1; $i <= $total_pages; $i++) : ?>
+                  <?php if ($i === $page) : ?>
+                    <span class="tablenav-pages-navspan button disabled"><?php echo $i; ?></span>
+                  <?php else : ?>
+                    <a class="button" href="<?php echo esc_url(add_query_arg('paged', $i)); ?>"><?php echo $i; ?></a>
+                  <?php endif; ?>
+                <?php endfor; ?>
+              </div>
+            </div>
+          <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    public static function handle_csv_export() {
+        if (!current_user_can('manage_options') || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'eeppj_pqrrs_csv')) {
+            wp_die('No autorizado.', 403);
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'eeppj_pqrrs';
+        $mode = sanitize_text_field($_GET['mode'] ?? 'summary');
+
+        if ($mode === 'detail') {
+            self::export_detail_csv($wpdb, $table);
+        } else {
+            self::export_summary_csv($wpdb, $table);
+        }
+        exit;
+    }
+
+    private static function export_summary_csv($wpdb, $table) {
+        $desde = sanitize_text_field($_GET['desde'] ?? date('Y-m', strtotime('-11 months')));
+        $hasta = sanitize_text_field($_GET['hasta'] ?? date('Y-m'));
+
+        if (!preg_match('/^\d{4}-\d{2}$/', $desde) || !preg_match('/^\d{4}-\d{2}$/', $hasta)) {
+            wp_die('Parámetros inválidos.');
+        }
+
+        $date_start = $desde . '-01';
+        $date_end = date('Y-m-01', strtotime($hasta . '-01 +1 month'));
+
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT DATE_FORMAT(created_at, '%%Y-%%m') AS mes, tipo, COUNT(*) AS total
+             FROM $table
+             WHERE created_at >= %s AND created_at < %s
+             GROUP BY mes, tipo
+             ORDER BY mes DESC",
+            $date_start, $date_end
+        ));
+
+        $data = [];
+        foreach ($rows as $r) {
+            $data[$r->mes][$r->tipo] = (int) $r->total;
+        }
+
+        // Enumerate all months
+        $all_months = [];
+        $cursor = new DateTime($hasta . '-01');
+        $limit = new DateTime($desde . '-01');
+        while ($cursor >= $limit) {
+            $all_months[] = $cursor->format('Y-m');
+            $cursor->modify('-1 month');
+        }
+
+        $filename = 'pqrrs-resumen-' . $desde . '-a-' . $hasta . '.csv';
+        self::send_csv_headers($filename);
+
+        $out = fopen('php://output', 'w');
+        // UTF-8 BOM
+        fwrite($out, "\xEF\xBB\xBF");
+
+        fputcsv($out, ['Mes', 'Peticiones', 'Quejas', 'Reclamos', 'Recursos', 'Sugerencias', 'Total']);
+
+        foreach ($all_months as $ym) {
+            $month_data = isset($data[$ym]) ? $data[$ym] : [];
+            $row_total = 0;
+            $row = [self::get_month_name($ym)];
+            foreach (self::$tipos as $t) {
+                $cnt = isset($month_data[$t]) ? $month_data[$t] : 0;
+                $row[] = $cnt;
+                $row_total += $cnt;
+            }
+            $row[] = $row_total;
+            fputcsv($out, $row);
+        }
+
+        fclose($out);
+    }
+
+    private static function export_detail_csv($wpdb, $table) {
+        $mes = sanitize_text_field($_GET['mes'] ?? '');
+        if (!preg_match('/^\d{4}-\d{2}$/', $mes)) {
+            wp_die('Parámetros inválidos.');
+        }
+
+        $date_start = $mes . '-01';
+        $date_end = date('Y-m-01', strtotime($date_start . ' +1 month'));
+
+        $submissions = $wpdb->get_results($wpdb->prepare(
+            "SELECT submission_id, tipo, nombre, cedula, email, telefono, asunto, status, created_at
+             FROM $table
+             WHERE created_at >= %s AND created_at < %s
+             ORDER BY created_at DESC",
+            $date_start, $date_end
+        ));
+
+        $filename = 'pqrrs-detalle-' . $mes . '.csv';
+        self::send_csv_headers($filename);
+
+        $out = fopen('php://output', 'w');
+        // UTF-8 BOM
+        fwrite($out, "\xEF\xBB\xBF");
+
+        fputcsv($out, ['Radicado', 'Tipo', 'Nombre', 'Cedula', 'Email', 'Telefono', 'Asunto', 'Estado', 'Fecha']);
+
+        $status_labels = [];
+        foreach (self::$statuses as $k => $v) {
+            $status_labels[$k] = $v['label'];
+        }
+
+        foreach ($submissions as $s) {
+            fputcsv($out, [
+                $s->submission_id,
+                ucfirst($s->tipo),
+                $s->nombre,
+                $s->cedula,
+                $s->email,
+                $s->telefono,
+                $s->asunto,
+                isset($status_labels[$s->status]) ? $status_labels[$s->status] : $s->status,
+                wp_date('d/m/Y H:i', strtotime($s->created_at)),
+            ]);
+        }
+
+        fclose($out);
+    }
+
+    private static function send_csv_headers($filename) {
+        header('Content-Type: text/csv; charset=UTF-8');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+        header('Pragma: no-cache');
+        header('Expires: 0');
+    }
+}

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
@@ -236,7 +236,10 @@ class EEPPJ_PQRRS_Reports {
         $where = 'WHERE ' . implode(' AND ', $where_parts);
 
         $submissions = $wpdb->get_results(
-            "SELECT * FROM $table $where ORDER BY created_at DESC LIMIT $per_page OFFSET $offset"
+            $wpdb->prepare(
+                "SELECT * FROM $table $where ORDER BY created_at DESC LIMIT %d OFFSET %d",
+                $per_page, $offset
+            )
         );
         $total_filtered = (int) $wpdb->get_var("SELECT COUNT(*) FROM $table $where");
         $total_pages = (int) ceil($total_filtered / $per_page);
@@ -345,9 +348,9 @@ class EEPPJ_PQRRS_Reports {
               <div class="tablenav-pages">
                 <?php for ($i = 1; $i <= $total_pages; $i++) : ?>
                   <?php if ($i === $page) : ?>
-                    <span class="tablenav-pages-navspan button disabled"><?php echo $i; ?></span>
+                    <span class="tablenav-pages-navspan button disabled"><?php echo esc_html($i); ?></span>
                   <?php else : ?>
-                    <a class="button" href="<?php echo esc_url(add_query_arg('paged', $i)); ?>"><?php echo $i; ?></a>
+                    <a class="button" href="<?php echo esc_url(add_query_arg('paged', $i)); ?>"><?php echo esc_html($i); ?></a>
                   <?php endif; ?>
                 <?php endfor; ?>
               </div>
@@ -482,6 +485,7 @@ class EEPPJ_PQRRS_Reports {
     }
 
     private static function send_csv_headers($filename) {
+        $filename = sanitize_file_name($filename);
         header('Content-Type: text/csv; charset=UTF-8');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
         header('Pragma: no-cache');

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
@@ -260,10 +260,10 @@ class EEPPJ_PQRRS_Reports {
         $total_pages = (int) ceil($total_filtered / $per_page);
 
         $base_url = admin_url('admin.php?page=eeppj-pqrrs-reports&mes=' . $mes);
-        $csv_url = wp_nonce_url(
-            admin_url('admin-post.php?action=eeppj_pqrrs_csv&mode=detail&mes=' . $mes),
-            'eeppj_pqrrs_csv'
-        );
+        $csv_params = 'admin-post.php?action=eeppj_pqrrs_csv&mode=detail&mes=' . $mes;
+        if ($filter_tipo) $csv_params .= '&tipo=' . $filter_tipo;
+        if ($filter_status) $csv_params .= '&status=' . $filter_status;
+        $csv_url = wp_nonce_url(admin_url($csv_params), 'eeppj_pqrrs_csv');
         ?>
         <div class="wrap eeppj-admin">
           <a href="<?php echo esc_url(admin_url('admin.php?page=eeppj-pqrrs-reports')); ?>" class="eeppj-back-link">&larr; Volver a reportes</a>
@@ -379,7 +379,7 @@ class EEPPJ_PQRRS_Reports {
 
     public static function handle_csv_export() {
         if (!current_user_can('manage_options') || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'eeppj_pqrrs_csv')) {
-            wp_die('No autorizado.', 403);
+            wp_die('No autorizado.', 'No autorizado', ['response' => 403]);
         }
 
         global $wpdb;
@@ -419,7 +419,7 @@ class EEPPJ_PQRRS_Reports {
         ));
 
         if ($wpdb->last_error) {
-            wp_die('Error de base de datos: ' . esc_html($wpdb->last_error), 500);
+            wp_die('Error de base de datos: ' . esc_html($wpdb->last_error), 'Error', ['response' => 500]);
         }
 
         $data = [];
@@ -441,7 +441,7 @@ class EEPPJ_PQRRS_Reports {
 
         $out = fopen('php://output', 'w');
         if ($out === false) {
-            wp_die('Error interno al generar el archivo CSV.', 500);
+            wp_die('Error interno al generar el archivo CSV.', 'Error', ['response' => 500]);
         }
         // UTF-8 BOM
         fwrite($out, "\xEF\xBB\xBF");
@@ -473,16 +473,29 @@ class EEPPJ_PQRRS_Reports {
         $date_start = $mes . '-01';
         $date_end = date('Y-m-01', strtotime($date_start . ' +1 month'));
 
-        $submissions = $wpdb->get_results($wpdb->prepare(
+        // Apply optional tipo/status filters (same as detail view)
+        $filter_tipo = sanitize_text_field($_GET['tipo'] ?? '');
+        $filter_status = sanitize_text_field($_GET['status'] ?? '');
+
+        $where_parts = [
+            $wpdb->prepare("created_at >= %s", $date_start),
+            $wpdb->prepare("created_at < %s", $date_end),
+        ];
+        if ($filter_tipo && in_array($filter_tipo, self::$tipos, true)) {
+            $where_parts[] = $wpdb->prepare("tipo = %s", $filter_tipo);
+        }
+        if ($filter_status && isset(self::$statuses[$filter_status])) {
+            $where_parts[] = $wpdb->prepare("status = %s", $filter_status);
+        }
+        $where = 'WHERE ' . implode(' AND ', $where_parts);
+
+        $submissions = $wpdb->get_results(
             "SELECT submission_id, tipo, nombre, cedula, email, telefono, asunto, status, created_at
-             FROM $table
-             WHERE created_at >= %s AND created_at < %s
-             ORDER BY created_at DESC",
-            $date_start, $date_end
-        ));
+             FROM $table $where ORDER BY created_at DESC"
+        );
 
         if ($wpdb->last_error) {
-            wp_die('Error de base de datos: ' . esc_html($wpdb->last_error), 500);
+            wp_die('Error de base de datos: ' . esc_html($wpdb->last_error), 'Error', ['response' => 500]);
         }
 
         $filename = 'pqrrs-detalle-' . $mes . '.csv';
@@ -490,7 +503,7 @@ class EEPPJ_PQRRS_Reports {
 
         $out = fopen('php://output', 'w');
         if ($out === false) {
-            wp_die('Error interno al generar el archivo CSV.', 500);
+            wp_die('Error interno al generar el archivo CSV.', 'Error', ['response' => 500]);
         }
         // UTF-8 BOM
         fwrite($out, "\xEF\xBB\xBF");

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
@@ -50,7 +50,7 @@ class EEPPJ_PQRRS_Reports {
         if (!current_user_can('manage_options')) return;
 
         $mes = sanitize_text_field($_GET['mes'] ?? '');
-        if ($mes && preg_match('/^\d{4}-\d{2}$/', $mes)) {
+        if ($mes && preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $mes)) {
             self::render_month_detail($mes);
         } else {
             self::render_summary();
@@ -75,9 +75,14 @@ class EEPPJ_PQRRS_Reports {
         $desde = sanitize_text_field($_GET['desde'] ?? $default_desde);
         $hasta = sanitize_text_field($_GET['hasta'] ?? $default_hasta);
 
-        // Validate format
-        if (!preg_match('/^\d{4}-\d{2}$/', $desde)) $desde = $default_desde;
-        if (!preg_match('/^\d{4}-\d{2}$/', $hasta)) $hasta = $default_hasta;
+        // Validate format (only valid months 01-12)
+        if (!preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $desde)) $desde = $default_desde;
+        if (!preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $hasta)) $hasta = $default_hasta;
+
+        // Auto-swap if inverted
+        if ($desde > $hasta) {
+            list($desde, $hasta) = array($hasta, $desde);
+        }
 
         $date_start = $desde . '-01';
         // End of "hasta" month: first day of next month
@@ -92,6 +97,11 @@ class EEPPJ_PQRRS_Reports {
              ORDER BY mes DESC",
             $date_start, $date_end
         ));
+
+        if ($wpdb->last_error) {
+            echo '<div class="notice notice-error"><p>' . esc_html('Error de base de datos: ' . $wpdb->last_error) . '</p></div>';
+            return;
+        }
 
         // Build lookup: $data[month][tipo] = count
         $data = [];
@@ -222,6 +232,11 @@ class EEPPJ_PQRRS_Reports {
             $date_start, $date_end
         ), OBJECT_K);
 
+        if ($wpdb->last_error) {
+            echo '<div class="wrap eeppj-admin"><div class="notice notice-error"><p>' . esc_html('Error de base de datos: ' . $wpdb->last_error) . '</p></div></div>';
+            return;
+        }
+
         // Build WHERE for filtered list
         $where_parts = [
             $wpdb->prepare("created_at >= %s", $date_start),
@@ -320,7 +335,9 @@ class EEPPJ_PQRRS_Reports {
                 <tr><td colspan="7" style="text-align:center;color:#666;">No hay solicitudes en este período.</td></tr>
               <?php endif; ?>
               <?php foreach ($submissions as $s) :
-                  $st = self::$statuses[$s->status] ?? self::$statuses['pendiente'];
+                  $st = isset(self::$statuses[$s->status])
+                      ? self::$statuses[$s->status]
+                      : ['label' => ucfirst($s->status), 'color' => '#9ca3af', 'bg' => '#f9fafb'];
               ?>
                 <tr>
                   <td><code><?php echo esc_html($s->submission_id); ?></code></td>
@@ -381,12 +398,16 @@ class EEPPJ_PQRRS_Reports {
         $desde = sanitize_text_field($_GET['desde'] ?? date('Y-m', strtotime('-11 months')));
         $hasta = sanitize_text_field($_GET['hasta'] ?? date('Y-m'));
 
-        if (!preg_match('/^\d{4}-\d{2}$/', $desde) || !preg_match('/^\d{4}-\d{2}$/', $hasta)) {
+        if (!preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $desde) || !preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $hasta)) {
             wp_die('Parámetros inválidos.');
         }
 
         $date_start = $desde . '-01';
         $date_end = date('Y-m-01', strtotime($hasta . '-01 +1 month'));
+
+        if ($desde > $hasta) {
+            list($desde, $hasta) = array($hasta, $desde);
+        }
 
         $rows = $wpdb->get_results($wpdb->prepare(
             "SELECT DATE_FORMAT(created_at, '%%Y-%%m') AS mes, tipo, COUNT(*) AS total
@@ -396,6 +417,10 @@ class EEPPJ_PQRRS_Reports {
              ORDER BY mes DESC",
             $date_start, $date_end
         ));
+
+        if ($wpdb->last_error) {
+            wp_die('Error de base de datos: ' . esc_html($wpdb->last_error), 500);
+        }
 
         $data = [];
         foreach ($rows as $r) {
@@ -415,6 +440,9 @@ class EEPPJ_PQRRS_Reports {
         self::send_csv_headers($filename);
 
         $out = fopen('php://output', 'w');
+        if ($out === false) {
+            wp_die('Error interno al generar el archivo CSV.', 500);
+        }
         // UTF-8 BOM
         fwrite($out, "\xEF\xBB\xBF");
 
@@ -438,7 +466,7 @@ class EEPPJ_PQRRS_Reports {
 
     private static function export_detail_csv($wpdb, $table) {
         $mes = sanitize_text_field($_GET['mes'] ?? '');
-        if (!preg_match('/^\d{4}-\d{2}$/', $mes)) {
+        if (!preg_match('/^\d{4}-(0[1-9]|1[0-2])$/', $mes)) {
             wp_die('Parámetros inválidos.');
         }
 
@@ -453,10 +481,17 @@ class EEPPJ_PQRRS_Reports {
             $date_start, $date_end
         ));
 
+        if ($wpdb->last_error) {
+            wp_die('Error de base de datos: ' . esc_html($wpdb->last_error), 500);
+        }
+
         $filename = 'pqrrs-detalle-' . $mes . '.csv';
         self::send_csv_headers($filename);
 
         $out = fopen('php://output', 'w');
+        if ($out === false) {
+            wp_die('Error interno al generar el archivo CSV.', 500);
+        }
         // UTF-8 BOM
         fwrite($out, "\xEF\xBB\xBF");
 
@@ -488,6 +523,7 @@ class EEPPJ_PQRRS_Reports {
         $filename = sanitize_file_name($filename);
         header('Content-Type: text/csv; charset=UTF-8');
         header('Content-Disposition: attachment; filename="' . $filename . '"');
+        header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
         header('Pragma: no-cache');
         header('Expires: 0');
     }


### PR DESCRIPTION
## Summary
- Adds **PQRRS > Reportes** admin page with monthly summary view (date range selector, stat cards, per-month breakdown table with zero-filled gaps)
- Drill-down detail view per month with tipo/status filter pills, read-only submissions table, and pagination
- CSV export via `admin_post` hook — two modes: aggregated summary and individual submissions, with UTF-8 BOM for Excel compatibility with Spanish characters
- Security: `manage_options` capability + nonce verification + `$wpdb->prepare()` on all queries

## Files changed
| File | Change |
|------|--------|
| `includes/class-pqrrs-reports.php` | New — `EEPPJ_PQRRS_Reports` static class with all reporting logic |
| `eeppj-pqrrs.php` | Added `require_once` + `init()` call |
| `assets/css/pqrrs-admin.css` | Appended report-specific styles (date controls, numeric cells, back link) |

## Test plan
- [ ] Navigate to PQRRS > Reportes — summary table shows monthly breakdown
- [ ] Change date range — table and stat cards update correctly
- [ ] Click "Ver detalle" on a month — detail view shows individual submissions
- [ ] Use tipo/status filters on detail view
- [ ] Click "Exportar CSV" on summary — downloads aggregated CSV
- [ ] Click "Exportar CSV" on detail — downloads individual submissions CSV
- [ ] Open CSV in Excel — Spanish characters (tildes, ñ) display correctly
- [ ] Months with no submissions show zeros (not missing rows)
- [ ] PHP 7.4 lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)