### PR TITLE
Add homepage carousel section via widget area

### DIFF
--- a/wp-content/plugins/eeppj-carousel/build/editor.js
+++ b/wp-content/plugins/eeppj-carousel/build/editor.js
@@ -18,6 +18,7 @@
   var RangeControl = wp.components.RangeControl;
   var ToggleControl = wp.components.ToggleControl;
   var Button = wp.components.Button;
+  var SelectControl = wp.components.SelectControl;
   var Placeholder = wp.components.Placeholder;
 
   registerBlockType('eeppj/carousel', {
@@ -31,6 +32,7 @@
       autoplayDuration: { type: 'number', default: 5000 },
       showPlayPause: { type: 'boolean', default: true },
       blockId: { type: 'string', default: '' },
+      theme: { type: 'string', default: 'dark' },
     },
     supports: {
       align: ['wide', 'full'],
@@ -109,6 +111,15 @@
             label: 'Mostrar botón Play/Pausa',
             checked: attributes.showPlayPause,
             onChange: function (v) { setAttributes({ showPlayPause: v }); },
+          }),
+          el(SelectControl, {
+            label: 'Tema',
+            value: attributes.theme || 'dark',
+            options: [
+              { label: 'Oscuro', value: 'dark' },
+              { label: 'Claro', value: 'light' },
+            ],
+            onChange: function (v) { setAttributes({ theme: v }); },
           })
         )
       );

--- a/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
+++ b/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: EEPPJ Carousel
  * Description: Apple-style premium content carousel — Gutenberg block with autoplay, smooth transitions, and floating control bar.
- * Version: 1.4.1
+ * Version: 1.5.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
  * Author: EEPPJ
@@ -12,7 +12,7 @@
 
 defined('ABSPATH') || exit;
 
-define('EEPPJ_CAROUSEL_VERSION', '1.4.1');
+define('EEPPJ_CAROUSEL_VERSION', '1.5.0');
 define('EEPPJ_CAROUSEL_PATH', plugin_dir_path(__FILE__));
 define('EEPPJ_CAROUSEL_URL', plugin_dir_url(__FILE__));
 
@@ -77,6 +77,10 @@ function eeppj_carousel_register_block() {
                 'type'    => 'string',
                 'default' => '',
             ],
+            'theme' => [
+                'type'    => 'string',
+                'default' => 'dark',
+            ],
         ],
     ]);
 }
@@ -100,6 +104,8 @@ function eeppj_carousel_render($attributes) {
     $autoplay = (int) ($attributes['autoplayDuration'] ?? 5000);
     $show_play_pause = $attributes['showPlayPause'] ?? true;
     $block_id = !empty($attributes['blockId']) ? $attributes['blockId'] : 'eeppj-carousel-' . wp_unique_id();
+    $theme = isset($attributes['theme']) ? $attributes['theme'] : 'dark';
+    $theme_class = ($theme === 'light') ? ' eeppj-carousel--light' : '';
 
     if (empty($slides)) {
         return '';
@@ -109,7 +115,7 @@ function eeppj_carousel_render($attributes) {
 
     ob_start();
     ?>
-    <div class="eeppj-carousel"
+    <div class="eeppj-carousel<?php echo esc_attr($theme_class); ?>"
          id="<?php echo esc_attr($block_id); ?>"
          data-autoplay="<?php echo esc_attr($autoplay); ?>"
          data-show-controls="<?php echo $show_play_pause ? '1' : '0'; ?>"

--- a/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
+++ b/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
@@ -104,7 +104,10 @@ function eeppj_carousel_render($attributes) {
     $autoplay = (int) ($attributes['autoplayDuration'] ?? 5000);
     $show_play_pause = $attributes['showPlayPause'] ?? true;
     $block_id = !empty($attributes['blockId']) ? $attributes['blockId'] : 'eeppj-carousel-' . wp_unique_id();
-    $theme = isset($attributes['theme']) ? $attributes['theme'] : 'dark';
+    $allowed_themes = array('dark', 'light');
+    $theme = isset($attributes['theme']) && in_array($attributes['theme'], $allowed_themes, true)
+        ? $attributes['theme']
+        : 'dark';
     $theme_class = ($theme === 'light') ? ' eeppj-carousel--light' : '';
 
     if (empty($slides)) {

--- a/wp-content/themes/eeppj/assets/css/animations.css
+++ b/wp-content/themes/eeppj/assets/css/animations.css
@@ -33,13 +33,26 @@
   animation: cardFadeIn 0.6s ease-out forwards;
 }
 
+/* ====== Homepage featured section scroll-reveal ====== */
+.homepage-featured {
+  opacity: 0;
+  transform: translateY(2rem);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+.homepage-featured.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 /* ====== Reduce motion for accessibility ====== */
 @media (prefers-reduced-motion: reduce) {
   .hero-fade,
   .quick-card,
-  .service-card {
+  .service-card,
+  .homepage-featured {
     opacity: 1;
     transform: none;
     animation: none;
+    transition: none;
   }
 }

--- a/wp-content/themes/eeppj/assets/css/animations.css
+++ b/wp-content/themes/eeppj/assets/css/animations.css
@@ -34,7 +34,8 @@
 }
 
 /* ====== Homepage featured section scroll-reveal ====== */
-.homepage-featured {
+/* Visible by default; JS adds .has-reveal then .is-visible for animation */
+.homepage-featured.has-reveal {
   opacity: 0;
   transform: translateY(2rem);
   transition: opacity 0.8s ease, transform 0.8s ease;
@@ -49,7 +50,7 @@
   .hero-fade,
   .quick-card,
   .service-card,
-  .homepage-featured {
+  .homepage-featured.has-reveal {
     opacity: 1;
     transform: none;
     animation: none;

--- a/wp-content/themes/eeppj/front-page.php
+++ b/wp-content/themes/eeppj/front-page.php
@@ -179,13 +179,17 @@ $recent_posts = new WP_Query([
 </section>
 
 <!-- ====== FEATURED CAROUSEL ====== -->
-<?php if (is_active_sidebar('homepage-carousel')) : ?>
-<section class="homepage-featured" style="padding-top: 4rem; padding-bottom: 4rem; background-color: #000;">
+<?php if (is_active_sidebar('homepage-carousel')) :
+  ob_start();
+  dynamic_sidebar('homepage-carousel');
+  $carousel_output = ob_get_clean();
+  if (trim($carousel_output)) : ?>
+<section class="homepage-featured" style="padding-top: 4rem; padding-bottom: 4rem;">
   <div class="max-w-7xl px-4 sm\:px-6" style="margin-left: auto; margin-right: auto;">
-    <?php dynamic_sidebar('homepage-carousel'); ?>
+    <?php echo $carousel_output; ?>
   </div>
 </section>
-<?php endif; ?>
+<?php endif; endif; ?>
 
 <!-- ====== RECENT NEWS ====== -->
 <section style="padding-top: 4rem; padding-bottom: 6rem; background-color: var(--color-surface-muted);">
@@ -298,10 +302,12 @@ $recent_posts = new WP_Query([
   var el = document.querySelector('.homepage-featured');
   if (!el) return;
   if (!('IntersectionObserver' in window)) { el.classList.add('is-visible'); return; }
-  var observer = new IntersectionObserver(function(entries) {
-    if (entries[0].isIntersecting) { el.classList.add('is-visible'); observer.disconnect(); }
-  }, { threshold: 0.15 });
-  observer.observe(el);
+  try {
+    var observer = new IntersectionObserver(function(entries) {
+      if (entries.length > 0 && entries[0].isIntersecting) { el.classList.add('is-visible'); observer.disconnect(); }
+    }, { threshold: 0.15 });
+    observer.observe(el);
+  } catch (e) { el.classList.add('is-visible'); }
 })();
 </script>
 

--- a/wp-content/themes/eeppj/front-page.php
+++ b/wp-content/themes/eeppj/front-page.php
@@ -178,6 +178,15 @@ $recent_posts = new WP_Query([
   </div>
 </section>
 
+<!-- ====== FEATURED CAROUSEL ====== -->
+<?php if (is_active_sidebar('homepage-carousel')) : ?>
+<section class="homepage-featured" style="padding-top: 4rem; padding-bottom: 4rem; background-color: #000;">
+  <div class="max-w-7xl px-4 sm\:px-6" style="margin-left: auto; margin-right: auto;">
+    <?php dynamic_sidebar('homepage-carousel'); ?>
+  </div>
+</section>
+<?php endif; ?>
+
 <!-- ====== RECENT NEWS ====== -->
 <section style="padding-top: 4rem; padding-bottom: 6rem; background-color: var(--color-surface-muted);">
   <div class="max-w-7xl px-4 sm\:px-6" style="margin-left: auto; margin-right: auto;">
@@ -283,5 +292,17 @@ $recent_posts = new WP_Query([
     .news-grid { grid-template-columns: repeat(3, 1fr); }
   }
 </style>
+
+<script>
+(function() {
+  var el = document.querySelector('.homepage-featured');
+  if (!el) return;
+  if (!('IntersectionObserver' in window)) { el.classList.add('is-visible'); return; }
+  var observer = new IntersectionObserver(function(entries) {
+    if (entries[0].isIntersecting) { el.classList.add('is-visible'); observer.disconnect(); }
+  }, { threshold: 0.15 });
+  observer.observe(el);
+})();
+</script>
 
 <?php get_footer(); ?>

--- a/wp-content/themes/eeppj/front-page.php
+++ b/wp-content/themes/eeppj/front-page.php
@@ -301,6 +301,7 @@ $recent_posts = new WP_Query([
 (function() {
   var el = document.querySelector('.homepage-featured');
   if (!el) return;
+  el.classList.add('has-reveal');
   if (!('IntersectionObserver' in window)) { el.classList.add('is-visible'); return; }
   try {
     var observer = new IntersectionObserver(function(entries) {

--- a/wp-content/themes/eeppj/functions.php
+++ b/wp-content/themes/eeppj/functions.php
@@ -329,6 +329,16 @@ function eeppj_widgets_init() {
         'before_title'  => '<h3 class="text-white font-heading font-bold text-lg mb-4">',
         'after_title'   => '</h3>',
     ]);
+
+    register_sidebar([
+        'name'          => __('Destacados Homepage', 'eeppj'),
+        'id'            => 'homepage-carousel',
+        'description'   => __('Carrusel o contenido destacado en la página principal. Aparece entre las estadísticas y las noticias.', 'eeppj'),
+        'before_widget' => '<div class="widget homepage-carousel-widget %2$s">',
+        'after_widget'  => '</div>',
+        'before_title'  => '',
+        'after_title'   => '',
+    ]);
 }
 add_action('widgets_init', 'eeppj_widgets_init');
 

--- a/wp-content/themes/eeppj/style.css
+++ b/wp-content/themes/eeppj/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/jgarcesres/wp_eeppj
 Author: EEPPJ
 Author URI: https://eeppj.com.co
 Description: Custom WordPress theme for Empresas Públicas de Jericó S.A E.S.P. Faithfully reproduces the Astro site design with brand colors, typography, animations, and responsive layouts.
-Version: 1.3.1
+Version: 1.4.0
 Requires at least: 5.6
 Tested up to: 6.8
 Requires PHP: 7.4


### PR DESCRIPTION
## Summary
- Register **Destacados Homepage** widget area in the theme so editors can place the carousel block between the Stats Bar and Recent News on the homepage — no code changes needed for future content updates
- Add `theme` attribute (dark/light) to the carousel block with a selector in the block inspector sidebar, leveraging the existing CSS light variant
- Add scroll-reveal fade-in animation for the carousel section with `prefers-reduced-motion` support
- Section only renders when the widget area has content (`is_active_sidebar` guard)

## Version bumps
- Theme: 1.3.1 → 1.4.0
- Carousel plugin: 1.4.1 → 1.5.0

## Test plan
- [ ] Activate carousel plugin, go to **Appearance > Widgets** — "Destacados Homepage" area appears
- [ ] Add the `eeppj/carousel` block with 3-4 slides, save
- [ ] Visit homepage — carousel appears between Stats Bar and News with fade-in animation
- [ ] Toggle theme to "Claro" in widget editor — light variant renders correctly
- [ ] Remove all widgets from the area — carousel section disappears entirely
- [ ] Add carousel block to a regular page via block editor — works independently
- [ ] PHP 7.4 lint passes on all modified files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)