### PR TITLE
Fix Turnstile silent bypass and rate-limit IP spoofing

### DIFF
--- a/tests/setup-wp.sh
+++ b/tests/setup-wp.sh
@@ -12,6 +12,9 @@ echo "==> Setting permalink structure..."
 $WP rewrite structure '/%postname%/' --hard
 $WP rewrite flush --hard
 
+echo "==> Configuring PQRRS for CI (no Turnstile keys)..."
+$WP option update eeppj_pqrrs_require_turnstile 0
+
 echo "==> Creating pages..."
 
 # Homepage

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
@@ -30,9 +30,35 @@ class EEPPJ_PQRRS_Admin {
         add_action('admin_menu', [__CLASS__, 'add_menus']);
         add_action('admin_init', [__CLASS__, 'register_settings']);
         add_action('admin_enqueue_scripts', [__CLASS__, 'enqueue_admin_styles']);
+        add_action('admin_notices', [__CLASS__, 'turnstile_admin_notice']);
         add_action('wp_ajax_eeppj_pqrrs_delete', [__CLASS__, 'handle_delete']);
         add_action('wp_ajax_eeppj_pqrrs_status', [__CLASS__, 'handle_status_change']);
         add_action('wp_ajax_eeppj_pqrrs_notes', [__CLASS__, 'handle_save_notes']);
+    }
+
+    public static function turnstile_admin_notice() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+        $require = get_option('eeppj_pqrrs_require_turnstile', '1');
+        $site_key = get_option('eeppj_pqrrs_turnstile_site_key');
+        $secret   = get_option('eeppj_pqrrs_turnstile_secret');
+        $keys_missing = empty($site_key) || empty($secret);
+
+        if ($keys_missing && $require === '1') {
+            echo '<div class="notice notice-error"><p>';
+            echo '<strong>PQRRS:</strong> Turnstile CAPTCHA está habilitado pero las claves no están configuradas. ';
+            echo 'El formulario <strong>rechazará</strong> todas las solicitudes hasta que configure las claves en ';
+            echo '<a href="' . esc_url(admin_url('admin.php?page=eeppj-pqrrs-settings')) . '">Ajustes PQRRS</a>.';
+            echo '</p></div>';
+        } elseif ($keys_missing && $require !== '1') {
+            echo '<div class="notice notice-warning"><p>';
+            echo '<strong>PQRRS:</strong> El formulario está funcionando <strong>sin protección CAPTCHA</strong>. ';
+            echo 'Se recomienda configurar Cloudflare Turnstile en ';
+            echo '<a href="' . esc_url(admin_url('admin.php?page=eeppj-pqrrs-settings')) . '">Ajustes PQRRS</a> ';
+            echo 'para prevenir spam y abuso.';
+            echo '</p></div>';
+        }
     }
 
     public static function add_menus() {
@@ -53,6 +79,12 @@ class EEPPJ_PQRRS_Admin {
     public static function register_settings() {
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_turnstile_site_key');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_turnstile_secret');
+        register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_require_turnstile', [
+            'type' => 'string', 'default' => '1', 'sanitize_callback' => 'sanitize_text_field',
+        ]);
+        register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_trusted_ip_header', [
+            'type' => 'string', 'default' => '', 'sanitize_callback' => 'sanitize_text_field',
+        ]);
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_notification_email');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_webhook_url');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_max_upload', [
@@ -80,6 +112,28 @@ class EEPPJ_PQRRS_Admin {
               <tr>
                 <th>Turnstile Secret Key</th>
                 <td><input type="password" name="eeppj_pqrrs_turnstile_secret" value="<?php echo esc_attr(get_option('eeppj_pqrrs_turnstile_secret')); ?>" class="regular-text" /></td>
+              </tr>
+              <tr>
+                <th>Requerir Turnstile</th>
+                <td>
+                  <label>
+                    <input type="checkbox" name="eeppj_pqrrs_require_turnstile" value="1" <?php checked(get_option('eeppj_pqrrs_require_turnstile', '1'), '1'); ?> />
+                    Exigir verificación CAPTCHA en el formulario
+                  </label>
+                  <p class="description">Si está activado y las claves no están configuradas, el formulario rechazará las solicitudes. Desactive solo para desarrollo local.</p>
+                </td>
+              </tr>
+              <tr>
+                <th>Cabecera IP de confianza</th>
+                <td>
+                  <?php $trusted_header = get_option('eeppj_pqrrs_trusted_ip_header', ''); ?>
+                  <select name="eeppj_pqrrs_trusted_ip_header">
+                    <option value="" <?php selected($trusted_header, ''); ?>>Ninguna (usar REMOTE_ADDR)</option>
+                    <option value="HTTP_CF_CONNECTING_IP" <?php selected($trusted_header, 'HTTP_CF_CONNECTING_IP'); ?>>CF-Connecting-IP (Cloudflare)</option>
+                    <option value="HTTP_X_FORWARDED_FOR" <?php selected($trusted_header, 'HTTP_X_FORWARDED_FOR'); ?>>X-Forwarded-For (proxy genérico)</option>
+                  </select>
+                  <p class="description">Seleccione solo si el servidor está detrás de un proxy/CDN de confianza. De lo contrario, un atacante puede falsificar su IP para evadir el límite de solicitudes.</p>
+                </td>
               </tr>
               <tr>
                 <th>Email de Notificación</th>

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
@@ -80,16 +80,27 @@ class EEPPJ_PQRRS_Admin {
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_turnstile_site_key');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_turnstile_secret');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_require_turnstile', [
-            'type' => 'string', 'default' => '1', 'sanitize_callback' => 'sanitize_text_field',
+            'type' => 'string', 'default' => '1',
+            'sanitize_callback' => array(__CLASS__, 'sanitize_require_turnstile'),
         ]);
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_trusted_ip_header', [
-            'type' => 'string', 'default' => '', 'sanitize_callback' => 'sanitize_text_field',
+            'type' => 'string', 'default' => '',
+            'sanitize_callback' => array(__CLASS__, 'sanitize_trusted_header'),
         ]);
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_notification_email');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_webhook_url');
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_max_upload', [
             'type' => 'integer', 'default' => 5, 'sanitize_callback' => 'absint',
         ]);
+    }
+
+    public static function sanitize_require_turnstile($value) {
+        return ($value === '1') ? '1' : '0';
+    }
+
+    public static function sanitize_trusted_header($value) {
+        $allowed = array('', 'HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR');
+        return in_array($value, $allowed, true) ? $value : '';
     }
 
     public static function enqueue_admin_styles($hook) {
@@ -117,6 +128,7 @@ class EEPPJ_PQRRS_Admin {
                 <th>Requerir Turnstile</th>
                 <td>
                   <label>
+                    <input type="hidden" name="eeppj_pqrrs_require_turnstile" value="0" />
                     <input type="checkbox" name="eeppj_pqrrs_require_turnstile" value="1" <?php checked(get_option('eeppj_pqrrs_require_turnstile', '1'), '1'); ?> />
                     Exigir verificación CAPTCHA en el formulario
                   </label>

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-handler.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-handler.php
@@ -126,30 +126,30 @@ class EEPPJ_PQRRS_Handler {
 
     private static function get_client_ip() {
         $trusted_header = get_option('eeppj_pqrrs_trusted_ip_header', '');
+        $allowed_headers = array('HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR');
 
-        // Only check the admin-configured trusted header, then fall back to REMOTE_ADDR.
-        // This prevents IP spoofing via untrusted X-Forwarded-For / CF-Connecting-IP headers.
-        $headers = array('REMOTE_ADDR');
-        if (!empty($trusted_header)) {
-            array_unshift($headers, $trusted_header);
+        // Validate trusted header against allowlist (defense-in-depth against tampered option).
+        if (!empty($trusted_header) && !in_array($trusted_header, $allowed_headers, true)) {
+            error_log('EEPPJ PQRRS: Invalid trusted_ip_header option value: ' . $trusted_header . '. Ignoring.');
+            $trusted_header = '';
         }
 
-        foreach ($headers as $header) {
-            if (!empty($_SERVER[$header])) {
-                $ip = explode(',', sanitize_text_field($_SERVER[$header]))[0];
-                $ip = trim($ip);
-                if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                    return $ip;
-                }
+        // Check trusted proxy header first for public IP, then fall back to REMOTE_ADDR.
+        if (!empty($trusted_header) && !empty($_SERVER[$trusted_header])) {
+            $ip = explode(',', sanitize_text_field($_SERVER[$trusted_header]))[0];
+            $ip = trim($ip);
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                return $ip;
             }
         }
 
-        // Fallback: accept REMOTE_ADDR even if private (local dev / intranet).
+        // REMOTE_ADDR: accept any valid IP including private ranges (local dev / intranet).
         $remote = isset($_SERVER['REMOTE_ADDR']) ? trim(sanitize_text_field($_SERVER['REMOTE_ADDR'])) : '';
         if (filter_var($remote, FILTER_VALIDATE_IP)) {
             return $remote;
         }
 
+        error_log('EEPPJ PQRRS: Could not determine client IP. REMOTE_ADDR is missing or invalid.');
         return '0.0.0.0';
     }
 }

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-handler.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-handler.php
@@ -125,16 +125,31 @@ class EEPPJ_PQRRS_Handler {
     }
 
     private static function get_client_ip() {
-        $headers = ['HTTP_CF_CONNECTING_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR'];
+        $trusted_header = get_option('eeppj_pqrrs_trusted_ip_header', '');
+
+        // Only check the admin-configured trusted header, then fall back to REMOTE_ADDR.
+        // This prevents IP spoofing via untrusted X-Forwarded-For / CF-Connecting-IP headers.
+        $headers = array('REMOTE_ADDR');
+        if (!empty($trusted_header)) {
+            array_unshift($headers, $trusted_header);
+        }
+
         foreach ($headers as $header) {
             if (!empty($_SERVER[$header])) {
-                $ip = explode(',', $_SERVER[$header])[0];
+                $ip = explode(',', sanitize_text_field($_SERVER[$header]))[0];
                 $ip = trim($ip);
-                if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
                     return $ip;
                 }
             }
         }
+
+        // Fallback: accept REMOTE_ADDR even if private (local dev / intranet).
+        $remote = isset($_SERVER['REMOTE_ADDR']) ? trim(sanitize_text_field($_SERVER['REMOTE_ADDR'])) : '';
+        if (filter_var($remote, FILTER_VALIDATE_IP)) {
+            return $remote;
+        }
+
         return '0.0.0.0';
     }
 }

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-turnstile.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-turnstile.php
@@ -18,11 +18,14 @@ class EEPPJ_PQRRS_Turnstile {
      * @return true|string  True if valid, error message if not
      */
     public static function verify($token, $ip = '') {
-        $secret = get_option('eeppj_pqrrs_turnstile_secret');
+        $secret  = get_option('eeppj_pqrrs_turnstile_secret');
+        $require = get_option('eeppj_pqrrs_require_turnstile', '1');
 
         if (empty($secret)) {
-            // No Turnstile configured — skip verification.
-            // In production, configure keys in PQRRS > Ajustes to enforce CAPTCHA.
+            if ($require === '1') {
+                return 'CAPTCHA no configurado. Contacte al administrador del sitio.';
+            }
+            // Turnstile explicitly disabled — skip verification (dev/testing only).
             return true;
         }
 

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-turnstile.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-turnstile.php
@@ -18,10 +18,12 @@ class EEPPJ_PQRRS_Turnstile {
      * @return true|string  True if valid, error message if not
      */
     public static function verify($token, $ip = '') {
-        $secret  = get_option('eeppj_pqrrs_turnstile_secret');
-        $require = get_option('eeppj_pqrrs_require_turnstile', '1');
+        $secret   = get_option('eeppj_pqrrs_turnstile_secret');
+        $site_key = get_option('eeppj_pqrrs_turnstile_site_key');
+        $require  = get_option('eeppj_pqrrs_require_turnstile', '1');
+        $keys_missing = empty($secret) || empty($site_key);
 
-        if (empty($secret)) {
+        if ($keys_missing) {
             if ($require === '1') {
                 return 'CAPTCHA no configurado. Contacte al administrador del sitio.';
             }

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-turnstile.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-turnstile.php
@@ -43,12 +43,15 @@ class EEPPJ_PQRRS_Turnstile {
         ]);
 
         if (is_wp_error($response)) {
+            error_log('EEPPJ PQRRS Turnstile verification failed: ' . $response->get_error_message());
             return 'Error al verificar CAPTCHA. Intente de nuevo.';
         }
 
         $body = json_decode(wp_remote_retrieve_body($response), true);
 
         if (empty($body['success'])) {
+            $error_codes = isset($body['error-codes']) ? implode(', ', $body['error-codes']) : 'unknown';
+            error_log('EEPPJ PQRRS Turnstile rejected token. Error codes: ' . $error_codes);
             return 'Verificación CAPTCHA fallida. Intente de nuevo.';
         }
 


### PR DESCRIPTION
## Summary
- **Turnstile CAPTCHA**: Added configurable "Require Turnstile" setting (default: on). When enabled without keys, form rejects submissions with clear error instead of silently bypassing CAPTCHA. Admin notices (error/warning) surface the misconfiguration.
- **Rate limiting**: Replaced blind trust of `CF-Connecting-IP`/`X-Forwarded-For` with admin-configured "trusted IP header" dropdown (default: `REMOTE_ADDR` only). Prevents attackers from spoofing IPs to bypass the 5-req/min limit.
- Both settings added to PQRRS > Ajustes with clear Spanish descriptions.

## Security findings addressed
- **HIGH**: Turnstile CAPTCHA silent bypass when keys unconfigured (`class-pqrrs-turnstile.php`)
- **HIGH**: Rate limiting bypass via IP header spoofing (`class-pqrrs-handler.php`)

## Test plan
- [ ] Verify with Turnstile keys configured: form works normally with CAPTCHA
- [ ] Verify with keys missing + "Require Turnstile" ON: form rejects with "CAPTCHA no configurado" + red admin notice
- [ ] Verify with keys missing + "Require Turnstile" OFF: form works without CAPTCHA + yellow admin warning
- [ ] Verify rate limiting uses REMOTE_ADDR by default (no trusted header selected)
- [ ] Verify selecting CF-Connecting-IP trusts that header for rate limiting
- [ ] Verify PHP 7.4 compatibility (no modern syntax used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)