### PR TITLE
Security hardening: headers, DOM XSS, block schema, updater integrity

### DIFF
--- a/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
+++ b/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
@@ -64,6 +64,16 @@ function eeppj_carousel_register_block() {
             'slides' => [
                 'type'    => 'array',
                 'default' => [],
+                'items'   => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'headline'    => ['type' => 'string'],
+                        'description' => ['type' => 'string'],
+                        'mediaUrl'    => ['type' => 'string'],
+                        'mediaId'     => ['type' => 'integer'],
+                        'mediaType'   => ['type' => 'string'],
+                    ],
+                ],
             ],
             'autoplayDuration' => [
                 'type'    => 'number',

--- a/wp-content/plugins/eeppj-carousel/includes/class-github-updater.php
+++ b/wp-content/plugins/eeppj-carousel/includes/class-github-updater.php
@@ -272,8 +272,6 @@ class EEPPJ_Carousel_GitHub_Updater {
         }
 
         return $best_release;
-
-        return null;
     }
 
     /**
@@ -323,7 +321,11 @@ class EEPPJ_Carousel_GitHub_Updater {
 
         foreach ($release['assets'] as $asset) {
             if (isset($asset['name']) && $asset['name'] === $this->asset_name) {
-                return isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
+                $url = isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
+                if ($url && strpos($url, 'https://github.com/') !== 0) {
+                    return null;
+                }
+                return $url;
             }
         }
 

--- a/wp-content/plugins/eeppj-carousel/includes/class-github-updater.php
+++ b/wp-content/plugins/eeppj-carousel/includes/class-github-updater.php
@@ -322,7 +322,9 @@ class EEPPJ_Carousel_GitHub_Updater {
         foreach ($release['assets'] as $asset) {
             if (isset($asset['name']) && $asset['name'] === $this->asset_name) {
                 $url = isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
-                if ($url && strpos($url, 'https://github.com/') !== 0) {
+                $expected = 'https://github.com/' . $this->github_repo . '/releases/download/';
+                if ($url && strpos($url, $expected) !== 0) {
+                    error_log('EEPPJ Updater: Rejected download URL "' . $url . '" — expected prefix "' . $expected . '"');
                     return null;
                 }
                 return $url;

--- a/wp-content/plugins/eeppj-pqrrs/assets/js/pqrrs-form.js
+++ b/wp-content/plugins/eeppj-pqrrs/assets/js/pqrrs-form.js
@@ -87,6 +87,12 @@
     });
   }
 
+  function escHtml(str) {
+    var el = document.createElement('span');
+    el.textContent = str;
+    return el.innerHTML;
+  }
+
   function showStatus(html, type) {
     statusEl.innerHTML = html;
     statusEl.className = 'pqrrs-status ' + type;
@@ -138,7 +144,7 @@
           '<div style="display:flex;align-items:flex-start;gap:0.75rem;">' +
             '<svg style="width:1.25rem;height:1.25rem;color:#dc2626;flex-shrink:0;margin-top:0.125rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>' +
             '<div><p style="font-weight:600;">Error al enviar</p>' +
-            '<p style="margin-top:0.25rem;color:#b91c1c;">' + (err.message || 'No se pudo procesar su solicitud. Intente nuevamente o comuníquese por teléfono al +60 (4) 852 37 64.') + '</p></div>' +
+            '<p style="margin-top:0.25rem;color:#b91c1c;">' + escHtml(err.message || 'No se pudo procesar su solicitud. Intente nuevamente o comuníquese por teléfono al +60 (4) 852 37 64.') + '</p></div>' +
           '</div>',
           'error'
         );

--- a/wp-content/plugins/eeppj-pqrrs/assets/js/pqrrs-form.js
+++ b/wp-content/plugins/eeppj-pqrrs/assets/js/pqrrs-form.js
@@ -88,8 +88,9 @@
   }
 
   function escHtml(str) {
+    if (str == null) return '';
     var el = document.createElement('span');
-    el.textContent = str;
+    el.textContent = String(str);
     return el.innerHTML;
   }
 

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-github-updater.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-github-updater.php
@@ -322,7 +322,9 @@ class EEPPJ_PQRRS_GitHub_Updater {
         foreach ($release['assets'] as $asset) {
             if (isset($asset['name']) && $asset['name'] === $this->asset_name) {
                 $url = isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
-                if ($url && strpos($url, 'https://github.com/') !== 0) {
+                $expected = 'https://github.com/' . $this->github_repo . '/releases/download/';
+                if ($url && strpos($url, $expected) !== 0) {
+                    error_log('EEPPJ Updater: Rejected download URL "' . $url . '" — expected prefix "' . $expected . '"');
                     return null;
                 }
                 return $url;

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-github-updater.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-github-updater.php
@@ -272,8 +272,6 @@ class EEPPJ_PQRRS_GitHub_Updater {
         }
 
         return $best_release;
-
-        return null;
     }
 
     /**
@@ -323,7 +321,11 @@ class EEPPJ_PQRRS_GitHub_Updater {
 
         foreach ($release['assets'] as $asset) {
             if (isset($asset['name']) && $asset['name'] === $this->asset_name) {
-                return isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
+                $url = isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
+                if ($url && strpos($url, 'https://github.com/') !== 0) {
+                    return null;
+                }
+                return $url;
             }
         }
 

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
@@ -12,10 +12,10 @@ defined('ABSPATH') || exit;
 class EEPPJ_PQRRS_Admin {
 
     private static $statuses = [
-        'pendiente'   => ['label' => 'Pendiente',   'color' => '#d97706', 'bg' => '#fffbeb', 'icon' => '&#9679;'],
-        'en_progreso' => ['label' => 'En Progreso',  'color' => '#2563eb', 'bg' => '#eff6ff', 'icon' => '&#8635;'],
-        'completada'  => ['label' => 'Completada',   'color' => '#16a34a', 'bg' => '#f0fdf4', 'icon' => '&#10003;'],
-        'descartada'  => ['label' => 'Descartada',   'color' => '#6b7280', 'bg' => '#f3f4f6', 'icon' => '&#10005;'],
+        'pendiente'   => ['label' => 'Pendiente',   'color' => '#d97706', 'bg' => '#fffbeb', 'icon' => "\u{25CF}"],
+        'en_progreso' => ['label' => 'En Progreso',  'color' => '#2563eb', 'bg' => '#eff6ff', 'icon' => "\u{21BB}"],
+        'completada'  => ['label' => 'Completada',   'color' => '#16a34a', 'bg' => '#f0fdf4', 'icon' => "\u{2713}"],
+        'descartada'  => ['label' => 'Descartada',   'color' => '#6b7280', 'bg' => '#f3f4f6', 'icon' => "\u{2715}"],
     ];
 
     // Valid transitions: current_status => [allowed next statuses]
@@ -301,7 +301,7 @@ class EEPPJ_PQRRS_Admin {
                       </select>
                     <?php else : ?>
                       <span class="eeppj-status-badge" style="color:<?php echo esc_attr($st['color']); ?>;background:<?php echo esc_attr($st['bg']); ?>;">
-                        <?php echo $st['icon'] . ' ' . esc_html($st['label']); ?>
+                        <?php echo esc_html($st['icon'] . ' ' . $st['label']); ?>
                       </span>
                     <?php endif; ?>
                   </td>
@@ -408,7 +408,7 @@ class EEPPJ_PQRRS_Admin {
               var bar = document.getElementById('modal-status-bar');
               bar.style.background = st.bg;
               bar.style.border = '1px solid ' + st.color + '33';
-              document.getElementById('modal-status-text').innerHTML = st.icon + ' ' + st.label;
+              document.getElementById('modal-status-text').textContent = st.icon + ' ' + st.label;
               document.getElementById('modal-status-text').style.color = st.color;
 
               var updated = btn.dataset.updated;
@@ -419,7 +419,13 @@ class EEPPJ_PQRRS_Admin {
               var archivoTd = document.getElementById('modal-archivo');
               if(btn.dataset.archivo){
                 archivoRow.style.display = '';
-                archivoTd.innerHTML = '<a href="'+btn.dataset.archivo+'" target="_blank" class="button button-small">Descargar</a>';
+                archivoTd.textContent = '';
+                var link = document.createElement('a');
+                link.href = btn.dataset.archivo;
+                link.target = '_blank';
+                link.className = 'button button-small';
+                link.textContent = 'Descargar';
+                archivoTd.appendChild(link);
               } else {
                 archivoRow.style.display = 'none';
               }

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
@@ -423,6 +423,7 @@ class EEPPJ_PQRRS_Admin {
                 var link = document.createElement('a');
                 link.href = btn.dataset.archivo;
                 link.target = '_blank';
+                link.rel = 'noopener noreferrer';
                 link.className = 'button button-small';
                 link.textContent = 'Descargar';
                 archivoTd.appendChild(link);

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
@@ -417,7 +417,7 @@ class EEPPJ_PQRRS_Admin {
               // Archivo
               var archivoRow = document.getElementById('modal-archivo-row');
               var archivoTd = document.getElementById('modal-archivo');
-              if(btn.dataset.archivo){
+              if(btn.dataset.archivo && btn.dataset.archivo.indexOf('http') === 0){
                 archivoRow.style.display = '';
                 archivoTd.textContent = '';
                 var link = document.createElement('a');

--- a/wp-content/themes/eeppj/functions.php
+++ b/wp-content/themes/eeppj/functions.php
@@ -218,6 +218,18 @@ function eeppj_enqueue_assets() {
 }
 add_action('wp_enqueue_scripts', 'eeppj_enqueue_assets');
 
+/* ====== Security Headers ====== */
+function eeppj_security_headers() {
+    if (headers_sent()) {
+        return;
+    }
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: SAMEORIGIN');
+    header('Referrer-Policy: strict-origin-when-cross-origin');
+    header('Permissions-Policy: camera=(), microphone=(), geolocation=()');
+}
+add_action('send_headers', 'eeppj_security_headers');
+
 /* ====== Custom Nav Walker for Dropdowns ====== */
 class EEPPJ_Nav_Walker extends Walker_Nav_Menu {
     private $current_item_has_children = false;

--- a/wp-content/themes/eeppj/functions.php
+++ b/wp-content/themes/eeppj/functions.php
@@ -220,7 +220,8 @@ add_action('wp_enqueue_scripts', 'eeppj_enqueue_assets');
 
 /* ====== Security Headers ====== */
 function eeppj_security_headers() {
-    if (headers_sent()) {
+    if (headers_sent($file, $line)) {
+        error_log(sprintf('EEPPJ: Security headers not sent — output already started in %s on line %d', $file, $line));
         return;
     }
     header('X-Content-Type-Options: nosniff');

--- a/wp-content/themes/eeppj/includes/class-github-updater.php
+++ b/wp-content/themes/eeppj/includes/class-github-updater.php
@@ -272,8 +272,6 @@ class EEPPJ_Theme_GitHub_Updater {
         }
 
         return $best_release;
-
-        return null;
     }
 
     /**
@@ -323,7 +321,11 @@ class EEPPJ_Theme_GitHub_Updater {
 
         foreach ($release['assets'] as $asset) {
             if (isset($asset['name']) && $asset['name'] === $this->asset_name) {
-                return isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
+                $url = isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
+                if ($url && strpos($url, 'https://github.com/') !== 0) {
+                    return null;
+                }
+                return $url;
             }
         }
 

--- a/wp-content/themes/eeppj/includes/class-github-updater.php
+++ b/wp-content/themes/eeppj/includes/class-github-updater.php
@@ -322,7 +322,9 @@ class EEPPJ_Theme_GitHub_Updater {
         foreach ($release['assets'] as $asset) {
             if (isset($asset['name']) && $asset['name'] === $this->asset_name) {
                 $url = isset($asset['browser_download_url']) ? $asset['browser_download_url'] : null;
-                if ($url && strpos($url, 'https://github.com/') !== 0) {
+                $expected = 'https://github.com/' . $this->github_repo . '/releases/download/';
+                if ($url && strpos($url, $expected) !== 0) {
+                    error_log('EEPPJ Updater: Rejected download URL "' . $url . '" — expected prefix "' . $expected . '"');
                     return null;
                 }
                 return $url;


### PR DESCRIPTION
## Summary
- **Theme**: Add HTTP security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy) via `send_headers` hook
- **PQRRS**: Replace `innerHTML` with safe DOM API in admin modal and escape server error messages in form JS to prevent DOM XSS
- **Carousel**: Add `items` schema to `slides` block attribute for Gutenberg validation defense-in-depth
- **All 3 updaters**: Validate GitHub release download URLs start with `https://github.com/` + remove unreachable dead code

## Security findings addressed
- **MEDIUM**: Missing HTTP security headers (theme)
- **MEDIUM**: DOM XSS via innerHTML in PQRRS admin modal (`class-pqrrs-admin.php`)
- **MEDIUM**: DOM XSS via innerHTML with server error messages (`pqrrs-form.js`)
- **MEDIUM**: Missing items schema on carousel slides attribute (`eeppj-carousel.php`)
- **MEDIUM**: GitHub updater downloads without domain validation (all 3 copies)

## Test plan
- [ ] Verify security headers present in HTTP response (`curl -I`)
- [ ] Verify PQRRS admin modal still displays status icons, archivo link, and field data correctly
- [ ] Verify PQRRS form error messages display correctly (trigger a validation error)
- [ ] Verify carousel block still renders correctly in editor and frontend
- [ ] Verify theme/plugin auto-updater still detects new releases
- [ ] Verify PHP 7.4 compatibility (no modern syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)