### PR TITLE
Low-severity hardening: escaping, SSRF, DOCX validation, carousel input

### DIFF
--- a/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
+++ b/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
@@ -113,7 +113,9 @@ function eeppj_carousel_render($attributes) {
     $slides = $attributes['slides'] ?? [];
     $autoplay = (int) ($attributes['autoplayDuration'] ?? 5000);
     $show_play_pause = $attributes['showPlayPause'] ?? true;
-    $block_id = !empty($attributes['blockId']) ? $attributes['blockId'] : 'eeppj-carousel-' . wp_unique_id();
+    $block_id = (!empty($attributes['blockId']) && preg_match('/^[a-zA-Z0-9_-]+$/', $attributes['blockId']))
+        ? $attributes['blockId']
+        : 'eeppj-carousel-' . wp_unique_id();
     $allowed_themes = array('dark', 'light');
     $theme = isset($attributes['theme']) && in_array($attributes['theme'], $allowed_themes, true)
         ? $attributes['theme']
@@ -143,7 +145,10 @@ function eeppj_carousel_render($attributes) {
               $headline = $slide['headline'] ?? '';
               $description = $slide['description'] ?? '';
               $mediaUrl = $slide['mediaUrl'] ?? '';
-              $mediaType = $slide['mediaType'] ?? 'image';
+              $allowed_media = array('image', 'video');
+              $mediaType = isset($slide['mediaType']) && in_array($slide['mediaType'], $allowed_media, true)
+                  ? $slide['mediaType']
+                  : 'image';
               $is_active = ($i === 0);
           ?>
             <div class="eeppj-carousel__slide"

--- a/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
+++ b/wp-content/plugins/eeppj-carousel/eeppj-carousel.php
@@ -113,10 +113,12 @@ function eeppj_carousel_render($attributes) {
     $slides = $attributes['slides'] ?? [];
     $autoplay = (int) ($attributes['autoplayDuration'] ?? 5000);
     $show_play_pause = $attributes['showPlayPause'] ?? true;
-    $block_id = (!empty($attributes['blockId']) && preg_match('/^[a-zA-Z0-9_-]+$/', $attributes['blockId']))
-        ? $attributes['blockId']
+    $raw_id = isset($attributes['blockId']) && is_string($attributes['blockId']) ? $attributes['blockId'] : '';
+    $block_id = (!empty($raw_id) && preg_match('/^[a-zA-Z0-9_-]+$/', $raw_id))
+        ? $raw_id
         : 'eeppj-carousel-' . wp_unique_id();
     $allowed_themes = array('dark', 'light');
+    $allowed_media = array('image', 'video');
     $theme = isset($attributes['theme']) && in_array($attributes['theme'], $allowed_themes, true)
         ? $attributes['theme']
         : 'dark';
@@ -145,7 +147,6 @@ function eeppj_carousel_render($attributes) {
               $headline = $slide['headline'] ?? '';
               $description = $slide['description'] ?? '';
               $mediaUrl = $slide['mediaUrl'] ?? '';
-              $allowed_media = array('image', 'video');
               $mediaType = isset($slide['mediaType']) && in_array($slide['mediaType'], $allowed_media, true)
                   ? $slide['mediaType']
                   : 'image';

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-email.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-email.php
@@ -49,7 +49,7 @@ class EEPPJ_PQRRS_Email {
         // Optional webhook (Discord/Slack)
         $webhook_url = get_option('eeppj_pqrrs_webhook_url');
         if (!empty($webhook_url)) {
-            wp_remote_post($webhook_url, [
+            wp_safe_remote_post($webhook_url, [
                 'headers' => ['Content-Type' => 'application/json'],
                 'body'    => wp_json_encode([
                     'content' => sprintf(

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-validator.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-validator.php
@@ -75,6 +75,20 @@ class EEPPJ_PQRRS_Validator {
             return 'El contenido del archivo no coincide con su tipo declarado.';
         }
 
+        // For DOCX: verify it's actually an OOXML document, not just any ZIP file.
+        if ($ext === 'docx') {
+            $zip = new ZipArchive();
+            if ($zip->open($file['tmp_name']) === true) {
+                $has_content_types = ($zip->locateName('[Content_Types].xml') !== false);
+                $zip->close();
+                if (!$has_content_types) {
+                    return 'El archivo DOCX no es válido.';
+                }
+            } else {
+                return 'No se pudo verificar el archivo DOCX.';
+            }
+        }
+
         return true;
     }
 }

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-validator.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-validator.php
@@ -76,7 +76,7 @@ class EEPPJ_PQRRS_Validator {
         }
 
         // For DOCX: verify it's actually an OOXML document, not just any ZIP file.
-        if ($ext === 'docx') {
+        if ($ext === 'docx' && class_exists('ZipArchive')) {
             $zip = new ZipArchive();
             if ($zip->open($file['tmp_name']) === true) {
                 $has_content_types = ($zip->locateName('[Content_Types].xml') !== false);

--- a/wp-content/themes/eeppj/page-pqrrs.php
+++ b/wp-content/themes/eeppj/page-pqrrs.php
@@ -65,7 +65,7 @@ get_header();
           ];
           foreach ($types as $t) : ?>
             <div class="pqrrs-type-item">
-              <span class="pqrrs-type-letter" style="background: <?php echo $t['bg']; ?>; color: <?php echo $t['color']; ?>;"><?php echo $t['letter']; ?></span>
+              <span class="pqrrs-type-letter" style="background: <?php echo esc_attr($t['bg']); ?>; color: <?php echo esc_attr($t['color']); ?>;"><?php echo esc_html($t['letter']); ?></span>
               <div>
                 <p class="pqrrs-type-name"><?php echo esc_html($t['name']); ?></p>
                 <p class="pqrrs-type-desc"><?php echo esc_html($t['desc']); ?></p>

--- a/wp-content/themes/eeppj/page.php
+++ b/wp-content/themes/eeppj/page.php
@@ -13,7 +13,7 @@ get_header();
 <div style="background: rgba(140,192,75,0.05); border-bottom: 1px solid rgba(140,192,75,0.1);">
   <div class="max-w-7xl px-4" style="padding-top: 2rem; padding-bottom: 2rem; margin-left: auto; margin-right: auto;" class="page-hero-inner">
     <h1 style="font-size: 1.875rem; font-family: var(--font-heading); font-weight: 700; color: var(--color-brand-blue-dark);" class="page-hero-title">
-      <?php the_title(); ?>
+      <?php echo esc_html(get_the_title()); ?>
     </h1>
   </div>
 </div>

--- a/wp-content/themes/eeppj/single.php
+++ b/wp-content/themes/eeppj/single.php
@@ -26,7 +26,7 @@ while (have_posts()) : the_post();
       <?php endforeach; ?>
     </div>
     <h1 style="font-size: 1.875rem; font-family: var(--font-heading); font-weight: 700; color: var(--color-brand-blue-dark); line-height: 1.25;" class="single-title">
-      <?php the_title(); ?>
+      <?php echo esc_html(get_the_title()); ?>
     </h1>
   </div>
 


### PR DESCRIPTION
## Summary
- **Theme**: Escape `the_title()` output in page/single templates; add `esc_attr()` to PQRRS type card styles
- **PQRRS**: Use `wp_safe_remote_post()` for webhook (blocks private IP SSRF); validate DOCX uploads contain `[Content_Types].xml`
- **Carousel**: Validate `blockId` format with regex; add `mediaType` allowlist (`image`/`video`)

## Security findings addressed (all LOW severity)
- Unescaped `the_title()` in `page.php` and `single.php`
- Unescaped hardcoded style values in `page-pqrrs.php`
- Webhook URL potential SSRF via `wp_remote_post` 
- DOCX upload validation accepts any ZIP file
- `blockId` attribute accepts arbitrary strings
- `mediaType` not validated against allowlist

## Test plan
- [ ] Verify page and single post titles render correctly
- [ ] Verify PQRRS type cards display with correct colors
- [ ] Verify webhook notifications still work with Discord/Slack URLs
- [ ] Verify DOCX file upload still works; verify renamed ZIP is rejected
- [ ] Verify carousel renders with existing blocks
- [ ] Verify PHP 7.4 compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)