### PR TITLE
PII compliance (Ley 1581): encryption, retention, masking, privacy

### DIFF
--- a/wp-content/plugins/eeppj-pqrrs/assets/css/pqrrs-form.css
+++ b/wp-content/plugins/eeppj-pqrrs/assets/css/pqrrs-form.css
@@ -213,6 +213,32 @@ select.pqrrs-input {
   flex-shrink: 0;
 }
 
+/* ====== Privacy notice ====== */
+.pqrrs-privacy-notice {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: #4b5563;
+}
+
+.pqrrs-privacy-notice strong {
+  display: block;
+  font-size: 0.8125rem;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.pqrrs-privacy-notice p {
+  margin: 0 0 0.5rem;
+}
+
+.pqrrs-privacy-notice p:last-child {
+  margin-bottom: 0;
+}
+
 /* ====== Mobile refinements ====== */
 @media (max-width: 639px) {
   .pqrrs-input {

--- a/wp-content/plugins/eeppj-pqrrs/eeppj-pqrrs.php
+++ b/wp-content/plugins/eeppj-pqrrs/eeppj-pqrrs.php
@@ -37,7 +37,7 @@ function eeppj_pqrrs_activate() {
         id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
         submission_id VARCHAR(8) NOT NULL,
         nombre VARCHAR(255) NOT NULL,
-        cedula VARCHAR(20) DEFAULT '',
+        cedula VARCHAR(255) DEFAULT '',
         email VARCHAR(255) NOT NULL,
         telefono VARCHAR(20) DEFAULT '',
         tipo VARCHAR(20) NOT NULL,
@@ -60,7 +60,9 @@ function eeppj_pqrrs_activate() {
     update_option('eeppj_pqrrs_db_version', EEPPJ_PQRRS_VERSION);
 
     // Generate encryption key for PII fields
-    EEPPJ_PQRRS_Crypto::generate_key();
+    if (!EEPPJ_PQRRS_Crypto::generate_key()) {
+        error_log('EEPPJ PQRRS WARNING: Encryption key not generated during activation. Cedulas will be stored unencrypted.');
+    }
 
     // Schedule retention cron
     if (!wp_next_scheduled('eeppj_pqrrs_retention_cron')) {
@@ -116,6 +118,10 @@ function eeppj_pqrrs_check_db_upgrade() {
 
         // Widen cedula column for encrypted values (~120 chars)
         $wpdb->query("ALTER TABLE $table MODIFY cedula VARCHAR(255) DEFAULT ''");
+        if ($wpdb->last_error) {
+            error_log('EEPPJ PQRRS CRITICAL: Failed to widen cedula column: ' . $wpdb->last_error);
+            return; // Do NOT mark migration complete — encrypted values would be truncated
+        }
 
         // Generate encryption key if not present
         EEPPJ_PQRRS_Crypto::generate_key();
@@ -123,12 +129,23 @@ function eeppj_pqrrs_check_db_upgrade() {
         // Encrypt existing plaintext cedulas in batches
         if (EEPPJ_PQRRS_Crypto::is_configured()) {
             $batch_size = 50;
+            $max_iterations = 1000;
+            $iteration = 0;
             do {
+                if (++$iteration > $max_iterations) {
+                    error_log('EEPPJ PQRRS: Migration batch encryption exceeded ' . $max_iterations . ' iterations. Some cedulas may remain unencrypted.');
+                    break;
+                }
                 $rows = $wpdb->get_results(
                     "SELECT id, cedula FROM $table WHERE cedula != '' AND cedula NOT LIKE '%:%:%' AND cedula != '[ANONIMIZADO]' LIMIT $batch_size"
                 );
                 foreach ($rows as $row) {
                     $encrypted = EEPPJ_PQRRS_Crypto::encrypt($row->cedula);
+                    // If encrypt returned plaintext (no ':'), stop to avoid infinite loop
+                    if (strpos($encrypted, ':') === false) {
+                        error_log('EEPPJ PQRRS: Encryption failed during migration for record ID ' . $row->id . '. Stopping batch.');
+                        break 2;
+                    }
                     $wpdb->update($table, array('cedula' => $encrypted), array('id' => $row->id), array('%s'), array('%d'));
                 }
             } while (count($rows) === $batch_size);
@@ -174,13 +191,17 @@ function eeppj_pqrrs_run_retention() {
     }
 
     $count = 0;
+    $failed = 0;
     foreach ($rows as $row) {
         // Delete attachment if exists
         if ($row->archivo_id) {
-            wp_delete_attachment($row->archivo_id, true);
+            $deleted = wp_delete_attachment($row->archivo_id, true);
+            if (!$deleted) {
+                error_log('EEPPJ PQRRS: Retention cron failed to delete attachment ID ' . $row->archivo_id . ' for record ID ' . $row->id);
+            }
         }
 
-        $wpdb->update(
+        $result = $wpdb->update(
             $table,
             array(
                 'nombre'     => '[ANONIMIZADO]',
@@ -194,13 +215,20 @@ function eeppj_pqrrs_run_retention() {
             array('%s', '%s', '%s', '%s', '%s', '%s'),
             array('%d')
         );
+
+        if ($result === false) {
+            error_log('EEPPJ PQRRS: Retention cron FAILED to anonymize record ID ' . $row->id . ': ' . $wpdb->last_error);
+            $failed++;
+            continue;
+        }
+
         // Null out archivo_id separately (wpdb->update can't mix NULL with format strings)
         $wpdb->query($wpdb->prepare("UPDATE $table SET archivo_id = NULL WHERE id = %d", $row->id));
         $count++;
     }
 
-    if ($count > 0) {
-        error_log('EEPPJ PQRRS: Retention cron anonymized ' . $count . ' record(s).');
+    if ($count > 0 || $failed > 0) {
+        error_log('EEPPJ PQRRS: Retention cron completed — anonymized ' . $count . ', failed ' . $failed . '.');
     }
 }
 add_action('eeppj_pqrrs_retention_cron', 'eeppj_pqrrs_run_retention');

--- a/wp-content/plugins/eeppj-pqrrs/eeppj-pqrrs.php
+++ b/wp-content/plugins/eeppj-pqrrs/eeppj-pqrrs.php
@@ -3,7 +3,7 @@
  * Plugin Name: EEPPJ PQRRS
  * Plugin URI: https://github.com/jgarcesres/wp_eeppj
  * Description: PQRRS (Peticiones, Quejas, Reclamos, Recursos, Sugerencias) form handler for Empresas Públicas de Jericó. Provides form shortcode, Turnstile CAPTCHA, file upload validation, admin panel, and email notifications.
- * Version: 1.4.0
+ * Version: 1.5.0
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Author: EEPPJ
@@ -13,11 +13,12 @@
 
 defined('ABSPATH') || exit;
 
-define('EEPPJ_PQRRS_VERSION', '1.4.0');
+define('EEPPJ_PQRRS_VERSION', '1.5.0');
 define('EEPPJ_PQRRS_PATH', plugin_dir_path(__FILE__));
 define('EEPPJ_PQRRS_URL', plugin_dir_url(__FILE__));
 
 // Autoload classes
+require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-crypto.php';
 require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-validator.php';
 require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-turnstile.php';
 require_once EEPPJ_PQRRS_PATH . 'includes/class-pqrrs-handler.php';
@@ -57,8 +58,25 @@ function eeppj_pqrrs_activate() {
     dbDelta($sql);
 
     update_option('eeppj_pqrrs_db_version', EEPPJ_PQRRS_VERSION);
+
+    // Generate encryption key for PII fields
+    EEPPJ_PQRRS_Crypto::generate_key();
+
+    // Schedule retention cron
+    if (!wp_next_scheduled('eeppj_pqrrs_retention_cron')) {
+        wp_schedule_event(time(), 'daily', 'eeppj_pqrrs_retention_cron');
+    }
 }
 register_activation_hook(__FILE__, 'eeppj_pqrrs_activate');
+
+/* ====== Deactivation: clear cron ====== */
+function eeppj_pqrrs_deactivate() {
+    $timestamp = wp_next_scheduled('eeppj_pqrrs_retention_cron');
+    if ($timestamp) {
+        wp_unschedule_event($timestamp, 'eeppj_pqrrs_retention_cron');
+    }
+}
+register_deactivation_hook(__FILE__, 'eeppj_pqrrs_deactivate');
 
 /* ====== DB migration for existing installs ====== */
 function eeppj_pqrrs_check_db_upgrade() {
@@ -87,9 +105,105 @@ function eeppj_pqrrs_check_db_upgrade() {
         }
 
         update_option('eeppj_pqrrs_db_version', '1.2.0');
+        $installed = '1.2.0';
+    }
+
+    if (version_compare($installed, '1.5.0', '<')) {
+        global $wpdb;
+        if (!isset($table)) {
+            $table = $wpdb->prefix . 'eeppj_pqrrs';
+        }
+
+        // Widen cedula column for encrypted values (~120 chars)
+        $wpdb->query("ALTER TABLE $table MODIFY cedula VARCHAR(255) DEFAULT ''");
+
+        // Generate encryption key if not present
+        EEPPJ_PQRRS_Crypto::generate_key();
+
+        // Encrypt existing plaintext cedulas in batches
+        if (EEPPJ_PQRRS_Crypto::is_configured()) {
+            $batch_size = 50;
+            do {
+                $rows = $wpdb->get_results(
+                    "SELECT id, cedula FROM $table WHERE cedula != '' AND cedula NOT LIKE '%:%:%' AND cedula != '[ANONIMIZADO]' LIMIT $batch_size"
+                );
+                foreach ($rows as $row) {
+                    $encrypted = EEPPJ_PQRRS_Crypto::encrypt($row->cedula);
+                    $wpdb->update($table, array('cedula' => $encrypted), array('id' => $row->id), array('%s'), array('%d'));
+                }
+            } while (count($rows) === $batch_size);
+        }
+
+        // Schedule retention cron for existing installs
+        if (!wp_next_scheduled('eeppj_pqrrs_retention_cron')) {
+            wp_schedule_event(time(), 'daily', 'eeppj_pqrrs_retention_cron');
+        }
+
+        update_option('eeppj_pqrrs_db_version', '1.5.0');
     }
 }
 add_action('admin_init', 'eeppj_pqrrs_check_db_upgrade');
+
+/* ====== Data retention cron handler ====== */
+function eeppj_pqrrs_run_retention() {
+    if (get_option('eeppj_pqrrs_retention_enabled', '1') !== '1') {
+        return;
+    }
+
+    $days = (int) get_option('eeppj_pqrrs_retention_days', 730);
+    if ($days < 30) {
+        $days = 730;
+    }
+
+    $cutoff = date('Y-m-d H:i:s', strtotime("-{$days} days"));
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'eeppj_pqrrs';
+
+    $rows = $wpdb->get_results($wpdb->prepare(
+        "SELECT id, archivo_id FROM $table
+         WHERE status IN ('completada', 'descartada')
+         AND created_at < %s
+         AND nombre != '[ANONIMIZADO]'
+         LIMIT 100",
+        $cutoff
+    ));
+
+    if (empty($rows)) {
+        return;
+    }
+
+    $count = 0;
+    foreach ($rows as $row) {
+        // Delete attachment if exists
+        if ($row->archivo_id) {
+            wp_delete_attachment($row->archivo_id, true);
+        }
+
+        $wpdb->update(
+            $table,
+            array(
+                'nombre'     => '[ANONIMIZADO]',
+                'cedula'     => '[ANONIMIZADO]',
+                'email'      => '[ANONIMIZADO]',
+                'telefono'   => '',
+                'ip_address' => '0.0.0.0',
+                'updated_at' => current_time('mysql'),
+            ),
+            array('id' => $row->id),
+            array('%s', '%s', '%s', '%s', '%s', '%s'),
+            array('%d')
+        );
+        // Null out archivo_id separately (wpdb->update can't mix NULL with format strings)
+        $wpdb->query($wpdb->prepare("UPDATE $table SET archivo_id = NULL WHERE id = %d", $row->id));
+        $count++;
+    }
+
+    if ($count > 0) {
+        error_log('EEPPJ PQRRS: Retention cron anonymized ' . $count . ' record(s).');
+    }
+}
+add_action('eeppj_pqrrs_retention_cron', 'eeppj_pqrrs_run_retention');
 
 /* ====== Initialize plugin components ====== */
 function eeppj_pqrrs_init() {

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-admin.php
@@ -59,6 +59,16 @@ class EEPPJ_PQRRS_Admin {
             echo 'para prevenir spam y abuso.';
             echo '</p></div>';
         }
+
+        // Encryption notice
+        if (!EEPPJ_PQRRS_Crypto::is_configured()) {
+            echo '<div class="notice notice-warning"><p>';
+            echo '<strong>PQRRS:</strong> La clave de cifrado no está configurada. ';
+            echo 'Las cédulas se almacenan <strong>sin cifrar</strong>. ';
+            echo 'Desactive y reactive el plugin para generar la clave automáticamente, ';
+            echo 'o defina <code>EEPPJ_PQRRS_ENCRYPTION_KEY</code> en <code>wp-config.php</code>.';
+            echo '</p></div>';
+        }
     }
 
     public static function add_menus() {
@@ -92,6 +102,17 @@ class EEPPJ_PQRRS_Admin {
         register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_max_upload', [
             'type' => 'integer', 'default' => 5, 'sanitize_callback' => 'absint',
         ]);
+        register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_retention_enabled', [
+            'type' => 'string', 'default' => '1',
+            'sanitize_callback' => array(__CLASS__, 'sanitize_retention_enabled'),
+        ]);
+        register_setting('eeppj_pqrrs_settings', 'eeppj_pqrrs_retention_days', [
+            'type' => 'integer', 'default' => 730, 'sanitize_callback' => 'absint',
+        ]);
+    }
+
+    public static function sanitize_retention_enabled($value) {
+        return ($value === '1') ? '1' : '0';
     }
 
     public static function sanitize_require_turnstile($value) {
@@ -164,6 +185,28 @@ class EEPPJ_PQRRS_Admin {
               <tr>
                 <th>Tamaño máximo de archivo (MB)</th>
                 <td><input type="number" name="eeppj_pqrrs_max_upload" value="<?php echo esc_attr(get_option('eeppj_pqrrs_max_upload', 5)); ?>" min="1" max="25" class="small-text" /></td>
+              </tr>
+            </table>
+
+            <h2>Retención de datos (Ley 1581)</h2>
+            <table class="form-table">
+              <tr>
+                <th>Anonimización automática</th>
+                <td>
+                  <label>
+                    <input type="hidden" name="eeppj_pqrrs_retention_enabled" value="0" />
+                    <input type="checkbox" name="eeppj_pqrrs_retention_enabled" value="1" <?php checked(get_option('eeppj_pqrrs_retention_enabled', '1'), '1'); ?> />
+                    Habilitar anonimización automática de solicitudes cerradas
+                  </label>
+                  <p class="description">Solicitudes completadas o descartadas serán anonimizadas después del período de retención. Solo aplica a solicitudes cerradas.</p>
+                </td>
+              </tr>
+              <tr>
+                <th>Período de retención (días)</th>
+                <td>
+                  <input type="number" name="eeppj_pqrrs_retention_days" value="<?php echo esc_attr(get_option('eeppj_pqrrs_retention_days', 730)); ?>" min="30" max="3650" class="small-text" />
+                  <p class="description">Días antes de anonimizar datos personales (mínimo 30, máximo 3650). Por defecto: 730 (2 años).</p>
+                </td>
               </tr>
             </table>
             <?php submit_button('Guardar Ajustes'); ?>
@@ -313,7 +356,7 @@ class EEPPJ_PQRRS_Admin {
                       data-id="<?php echo esc_attr($s->id); ?>"
                       data-sid="<?php echo esc_attr($s->submission_id); ?>"
                       data-nombre="<?php echo esc_attr($s->nombre); ?>"
-                      data-cedula="<?php echo esc_attr($s->cedula); ?>"
+                      data-cedula="<?php echo esc_attr(EEPPJ_PQRRS_Crypto::decrypt($s->cedula)); ?>"
                       data-email="<?php echo esc_attr($s->email); ?>"
                       data-telefono="<?php echo esc_attr($s->telefono); ?>"
                       data-tipo="<?php echo esc_attr($s->tipo); ?>"

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-crypto.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-crypto.php
@@ -2,6 +2,11 @@
 /**
  * PQRRS Crypto — AES-256-CBC encryption for PII fields (cedula)
  *
+ * Key storage: The encryption key is stored in the DB encrypted with AUTH_KEY.
+ * This means security depends on AUTH_KEY confidentiality. If an attacker has
+ * both DB access and wp-config.php, they can unwrap the key. For stronger
+ * isolation, define EEPPJ_PQRRS_ENCRYPTION_KEY in wp-config.php instead.
+ *
  * @package eeppj-pqrrs
  */
 
@@ -25,13 +30,19 @@ class EEPPJ_PQRRS_Crypto {
 
         $key = self::get_key();
         if ($key === false) {
+            error_log('EEPPJ PQRRS CRITICAL: Encryption key unavailable. Cedula stored without encryption.');
             return $plaintext;
         }
 
-        $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(self::$cipher));
+        $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(self::$cipher), $strong);
+        if (!$strong) {
+            error_log('EEPPJ PQRRS WARNING: openssl_random_pseudo_bytes did not produce cryptographically strong output for IV.');
+        }
+
         $ciphertext = openssl_encrypt($plaintext, self::$cipher, $key, OPENSSL_RAW_DATA, $iv);
 
         if ($ciphertext === false) {
+            error_log('EEPPJ PQRRS CRITICAL: openssl_encrypt failed. OpenSSL error: ' . openssl_error_string());
             return $plaintext;
         }
 
@@ -60,6 +71,7 @@ class EEPPJ_PQRRS_Crypto {
 
         $key = self::get_key();
         if ($key === false) {
+            error_log('EEPPJ PQRRS: Decryption failed — encryption key unavailable.');
             return '[ERROR: clave no disponible]';
         }
 
@@ -68,18 +80,21 @@ class EEPPJ_PQRRS_Crypto {
         $ciphertext = base64_decode($parts[2], true);
 
         if ($iv === false || $hmac === false || $ciphertext === false) {
+            error_log('EEPPJ PQRRS: Decryption failed — corrupt base64 in stored value.');
             return $stored;
         }
 
         // Verify HMAC
         $expected_hmac = hash_hmac('sha256', $iv . $ciphertext, $key, true);
         if (!hash_equals($expected_hmac, $hmac)) {
+            error_log('EEPPJ PQRRS: Decryption failed — HMAC verification failed. Key may have changed.');
             return '[ERROR: HMAC inválido]';
         }
 
         $plaintext = openssl_decrypt($ciphertext, self::$cipher, $key, OPENSSL_RAW_DATA, $iv);
 
         if ($plaintext === false) {
+            error_log('EEPPJ PQRRS: Decryption failed — openssl_decrypt returned false. OpenSSL error: ' . openssl_error_string());
             return '[ERROR: descifrado fallido]';
         }
 
@@ -108,6 +123,7 @@ class EEPPJ_PQRRS_Crypto {
             if ($key !== false && strlen($key) === 32) {
                 return $key;
             }
+            error_log('EEPPJ PQRRS: EEPPJ_PQRRS_ENCRYPTION_KEY constant is defined but invalid (bad base64 or wrong length). Expected 32 bytes base64-encoded.');
         }
 
         // Fall back to DB option encrypted with AUTH_KEY
@@ -117,6 +133,7 @@ class EEPPJ_PQRRS_Crypto {
         }
 
         if (!defined('AUTH_KEY') || AUTH_KEY === '' || AUTH_KEY === 'put your unique phrase here') {
+            error_log('EEPPJ PQRRS: AUTH_KEY is not configured. Cannot unwrap encryption key from DB.');
             return false;
         }
 
@@ -125,12 +142,14 @@ class EEPPJ_PQRRS_Crypto {
 
         $decoded = base64_decode($stored, true);
         if ($decoded === false) {
+            error_log('EEPPJ PQRRS: Stored encryption key option contains invalid base64.');
             return false;
         }
 
         $key = openssl_decrypt($decoded, self::$cipher, $wrapping_key, OPENSSL_RAW_DATA, $wrapping_iv);
 
         if ($key === false || strlen($key) !== 32) {
+            error_log('EEPPJ PQRRS: Failed to unwrap encryption key from DB. AUTH_KEY may have changed since key was generated.');
             return false;
         }
 
@@ -149,10 +168,14 @@ class EEPPJ_PQRRS_Crypto {
         }
 
         if (!defined('AUTH_KEY') || AUTH_KEY === '' || AUTH_KEY === 'put your unique phrase here') {
+            error_log('EEPPJ PQRRS WARNING: Cannot generate encryption key — AUTH_KEY is not configured in wp-config.php.');
             return false;
         }
 
-        $key = openssl_random_pseudo_bytes(32);
+        $key = openssl_random_pseudo_bytes(32, $strong);
+        if (!$strong) {
+            error_log('EEPPJ PQRRS WARNING: openssl_random_pseudo_bytes did not produce cryptographically strong output for encryption key.');
+        }
 
         $wrapping_key = substr(hash('sha256', AUTH_KEY, true), 0, 32);
         $wrapping_iv = substr(hash('sha256', 'eeppj_pqrrs_iv' . AUTH_KEY, true), 0, 16);
@@ -160,10 +183,12 @@ class EEPPJ_PQRRS_Crypto {
         $encrypted = openssl_encrypt($key, self::$cipher, $wrapping_key, OPENSSL_RAW_DATA, $wrapping_iv);
 
         if ($encrypted === false) {
+            error_log('EEPPJ PQRRS: Failed to wrap encryption key. OpenSSL error: ' . openssl_error_string());
             return false;
         }
 
-        update_option(self::$option_name, base64_encode($encrypted));
+        // Store with autoload disabled — sensitive value, only needed during PII operations
+        update_option(self::$option_name, base64_encode($encrypted), '', 'no');
         return true;
     }
 }

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-crypto.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-crypto.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * PQRRS Crypto — AES-256-CBC encryption for PII fields (cedula)
+ *
+ * @package eeppj-pqrrs
+ */
+
+defined('ABSPATH') || exit;
+
+class EEPPJ_PQRRS_Crypto {
+
+    private static $cipher = 'aes-256-cbc';
+    private static $option_name = 'eeppj_pqrrs_encryption_key';
+
+    /**
+     * Encrypt plaintext using AES-256-CBC + HMAC-SHA256 (encrypt-then-MAC).
+     *
+     * @param string $plaintext
+     * @return string base64(iv):base64(hmac):base64(ciphertext) or original if key unavailable
+     */
+    public static function encrypt($plaintext) {
+        if ($plaintext === '' || $plaintext === null) {
+            return '';
+        }
+
+        $key = self::get_key();
+        if ($key === false) {
+            return $plaintext;
+        }
+
+        $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(self::$cipher));
+        $ciphertext = openssl_encrypt($plaintext, self::$cipher, $key, OPENSSL_RAW_DATA, $iv);
+
+        if ($ciphertext === false) {
+            return $plaintext;
+        }
+
+        $hmac = hash_hmac('sha256', $iv . $ciphertext, $key, true);
+
+        return base64_encode($iv) . ':' . base64_encode($hmac) . ':' . base64_encode($ciphertext);
+    }
+
+    /**
+     * Decrypt stored value. Detects encrypted format (contains two ':').
+     * Returns as-is if plaintext or anonymized.
+     *
+     * @param string $stored
+     * @return string
+     */
+    public static function decrypt($stored) {
+        if ($stored === '' || $stored === null || $stored === '[ANONIMIZADO]') {
+            return $stored === null ? '' : $stored;
+        }
+
+        // Not encrypted if it doesn't contain exactly two ':'
+        $parts = explode(':', $stored);
+        if (count($parts) !== 3) {
+            return $stored;
+        }
+
+        $key = self::get_key();
+        if ($key === false) {
+            return '[ERROR: clave no disponible]';
+        }
+
+        $iv = base64_decode($parts[0], true);
+        $hmac = base64_decode($parts[1], true);
+        $ciphertext = base64_decode($parts[2], true);
+
+        if ($iv === false || $hmac === false || $ciphertext === false) {
+            return $stored;
+        }
+
+        // Verify HMAC
+        $expected_hmac = hash_hmac('sha256', $iv . $ciphertext, $key, true);
+        if (!hash_equals($expected_hmac, $hmac)) {
+            return '[ERROR: HMAC inválido]';
+        }
+
+        $plaintext = openssl_decrypt($ciphertext, self::$cipher, $key, OPENSSL_RAW_DATA, $iv);
+
+        if ($plaintext === false) {
+            return '[ERROR: descifrado fallido]';
+        }
+
+        return $plaintext;
+    }
+
+    /**
+     * Check if encryption is configured and usable.
+     *
+     * @return bool
+     */
+    public static function is_configured() {
+        return self::get_key() !== false;
+    }
+
+    /**
+     * Retrieve the encryption key.
+     * Checks constant first, then DB option (decrypted with AUTH_KEY).
+     *
+     * @return string|false 32-byte key or false
+     */
+    public static function get_key() {
+        // Advanced users can define the key in wp-config.php
+        if (defined('EEPPJ_PQRRS_ENCRYPTION_KEY')) {
+            $key = base64_decode(EEPPJ_PQRRS_ENCRYPTION_KEY, true);
+            if ($key !== false && strlen($key) === 32) {
+                return $key;
+            }
+        }
+
+        // Fall back to DB option encrypted with AUTH_KEY
+        $stored = get_option(self::$option_name, '');
+        if (empty($stored)) {
+            return false;
+        }
+
+        if (!defined('AUTH_KEY') || AUTH_KEY === '' || AUTH_KEY === 'put your unique phrase here') {
+            return false;
+        }
+
+        $wrapping_key = substr(hash('sha256', AUTH_KEY, true), 0, 32);
+        $wrapping_iv = substr(hash('sha256', 'eeppj_pqrrs_iv' . AUTH_KEY, true), 0, 16);
+
+        $decoded = base64_decode($stored, true);
+        if ($decoded === false) {
+            return false;
+        }
+
+        $key = openssl_decrypt($decoded, self::$cipher, $wrapping_key, OPENSSL_RAW_DATA, $wrapping_iv);
+
+        if ($key === false || strlen($key) !== 32) {
+            return false;
+        }
+
+        return $key;
+    }
+
+    /**
+     * Generate a new 32-byte encryption key, encrypt with AUTH_KEY, store as option.
+     * Does nothing if a key already exists.
+     *
+     * @return bool true if key was generated or already exists
+     */
+    public static function generate_key() {
+        if (self::is_configured()) {
+            return true;
+        }
+
+        if (!defined('AUTH_KEY') || AUTH_KEY === '' || AUTH_KEY === 'put your unique phrase here') {
+            return false;
+        }
+
+        $key = openssl_random_pseudo_bytes(32);
+
+        $wrapping_key = substr(hash('sha256', AUTH_KEY, true), 0, 32);
+        $wrapping_iv = substr(hash('sha256', 'eeppj_pqrrs_iv' . AUTH_KEY, true), 0, 16);
+
+        $encrypted = openssl_encrypt($key, self::$cipher, $wrapping_key, OPENSSL_RAW_DATA, $wrapping_iv);
+
+        if ($encrypted === false) {
+            return false;
+        }
+
+        update_option(self::$option_name, base64_encode($encrypted));
+        return true;
+    }
+}

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-handler.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-handler.php
@@ -94,7 +94,7 @@ class EEPPJ_PQRRS_Handler {
         $inserted = $wpdb->insert($table, [
             'submission_id' => $submission_id,
             'nombre'        => $nombre,
-            'cedula'        => $cedula,
+            'cedula'        => EEPPJ_PQRRS_Crypto::encrypt($cedula),
             'email'         => $email,
             'telefono'      => $telefono,
             'tipo'          => $tipo,

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
@@ -497,6 +497,11 @@ class EEPPJ_PQRRS_Reports {
 
         $full_export = isset($_GET['full']) && $_GET['full'] === '1';
 
+        if ($full_export) {
+            $current_user = wp_get_current_user();
+            error_log('EEPPJ PQRRS AUDIT: Full PII CSV export for ' . $mes . ' by user "' . $current_user->user_login . '" (ID ' . $current_user->ID . ') from IP ' . ($_SERVER['REMOTE_ADDR'] ?? 'unknown'));
+        }
+
         $date_start = $mes . '-01';
         $date_end = date('Y-m-01', strtotime($date_start . ' +1 month'));
 

--- a/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
+++ b/wp-content/plugins/eeppj-pqrrs/includes/class-pqrrs-reports.php
@@ -39,6 +39,20 @@ class EEPPJ_PQRRS_Reports {
         add_action('admin_post_eeppj_pqrrs_csv', [__CLASS__, 'handle_csv_export']);
     }
 
+    /**
+     * Mask cedula showing only last 4 digits: ****1234
+     */
+    private static function mask_cedula($cedula) {
+        if ($cedula === '' || $cedula === null || $cedula === '[ANONIMIZADO]') {
+            return $cedula === null ? '' : $cedula;
+        }
+        $len = strlen($cedula);
+        if ($len <= 4) {
+            return str_repeat('*', $len);
+        }
+        return str_repeat('*', $len - 4) . substr($cedula, -4);
+    }
+
     public static function add_submenu() {
         add_submenu_page(
             'eeppj-pqrrs', 'Reportes PQRRS', 'Reportes', 'manage_options',
@@ -313,8 +327,19 @@ class EEPPJ_PQRRS_Reports {
             </div>
           </div>
 
-          <div style="margin-bottom:1rem;">
+          <div style="margin-bottom:1rem;padding:0.75rem 1rem;background:#fffbeb;border:1px solid #fbbf24;border-radius:8px;font-size:0.8125rem;color:#92400e;">
+            <strong>Ley 1581/2012 — Datos personales:</strong> El CSV estándar enmascara las cédulas. Use "Exportar completo" solo cuando sea estrictamente necesario y asegúrese de proteger el archivo resultante.
+          </div>
+          <div style="margin-bottom:1rem;display:flex;gap:0.5rem;">
             <a href="<?php echo esc_url($csv_url); ?>" class="button">Exportar CSV</a>
+            <?php
+            $full_csv_params = $csv_params . '&full=1';
+            $full_csv_url = wp_nonce_url(admin_url($full_csv_params), 'eeppj_pqrrs_csv');
+            ?>
+            <a href="<?php echo esc_url($full_csv_url); ?>" class="button"
+               onclick="return confirm('Este archivo contendrá datos personales completos (cédulas sin enmascarar) protegidos por la Ley 1581 de 2012.\n\nUsted es responsable de la custodia y tratamiento adecuado de estos datos.\n\n¿Desea continuar?');">
+              Exportar CSV completo
+            </a>
           </div>
 
           <!-- Submissions table (read-only) -->
@@ -470,6 +495,8 @@ class EEPPJ_PQRRS_Reports {
             wp_die('Parámetros inválidos.');
         }
 
+        $full_export = isset($_GET['full']) && $_GET['full'] === '1';
+
         $date_start = $mes . '-01';
         $date_end = date('Y-m-01', strtotime($date_start . ' +1 month'));
 
@@ -516,11 +543,14 @@ class EEPPJ_PQRRS_Reports {
         }
 
         foreach ($submissions as $s) {
+            $decrypted_cedula = EEPPJ_PQRRS_Crypto::decrypt($s->cedula);
+            $cedula_value = $full_export ? $decrypted_cedula : self::mask_cedula($decrypted_cedula);
+
             fputcsv($out, [
                 $s->submission_id,
                 ucfirst($s->tipo),
                 $s->nombre,
-                $s->cedula,
+                $cedula_value,
                 $s->email,
                 $s->telefono,
                 $s->asunto,

--- a/wp-content/plugins/eeppj-pqrrs/templates/form.php
+++ b/wp-content/plugins/eeppj-pqrrs/templates/form.php
@@ -84,6 +84,13 @@ defined('ABSPATH') || exit;
       </div>
     <?php endif; ?>
 
+    <div class="pqrrs-privacy-notice">
+      <strong>Aviso de privacidad — Ley 1581 de 2012</strong>
+      <p>Empresas Públicas de Jericó S.A E.S.P., como responsable del tratamiento de datos personales, le informa que los datos suministrados en este formulario (nombre, cédula, correo, teléfono e IP) serán utilizados exclusivamente para tramitar su solicitud PQRRS conforme a la Ley 1755 de 2015.</p>
+      <p>Sus datos se almacenan de forma cifrada y se conservan durante el período legalmente establecido, tras el cual son anonimizados automáticamente. Usted tiene derecho a conocer, actualizar, rectificar y solicitar la supresión de sus datos personales dirigiéndose a nuestra oficina de atención o al correo de contacto institucional.</p>
+      <p>Al enviar este formulario, usted autoriza el tratamiento de sus datos personales para los fines aquí descritos.</p>
+    </div>
+
     <button type="submit" class="btn-primary pqrrs-submit" id="pqrrs-submit">
       <svg style="width: 1.25rem; height: 1.25rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>

--- a/wp-content/plugins/eeppj-pqrrs/templates/form.php
+++ b/wp-content/plugins/eeppj-pqrrs/templates/form.php
@@ -87,7 +87,7 @@ defined('ABSPATH') || exit;
     <div class="pqrrs-privacy-notice">
       <strong>Aviso de privacidad — Ley 1581 de 2012</strong>
       <p>Empresas Públicas de Jericó S.A E.S.P., como responsable del tratamiento de datos personales, le informa que los datos suministrados en este formulario (nombre, cédula, correo, teléfono e IP) serán utilizados exclusivamente para tramitar su solicitud PQRRS conforme a la Ley 1755 de 2015.</p>
-      <p>Sus datos se almacenan de forma cifrada y se conservan durante el período legalmente establecido, tras el cual son anonimizados automáticamente. Usted tiene derecho a conocer, actualizar, rectificar y solicitar la supresión de sus datos personales dirigiéndose a nuestra oficina de atención o al correo de contacto institucional.</p>
+      <p>Su número de cédula se almacena de forma cifrada. Los datos se conservan durante el período legalmente establecido, tras el cual son anonimizados automáticamente. Usted tiene derecho a conocer, actualizar, rectificar y solicitar la supresión de sus datos personales dirigiéndose a nuestra oficina de atención o al correo de contacto institucional.</p>
       <p>Al enviar este formulario, usted autoriza el tratamiento de sus datos personales para los fines aquí descritos.</p>
     </div>
 


### PR DESCRIPTION
## Summary

- **Cedula encryption at rest**: New `EEPPJ_PQRRS_Crypto` class implements AES-256-CBC + HMAC-SHA256 (encrypt-then-MAC). Key auto-generated on activation, wrapped with AUTH_KEY in DB. DB migration widens cedula column and encrypts existing plaintext values in batches. Admin notice when encryption is not configured.
- **Data retention cron**: Daily cron anonymizes completed/discarded PQRRS records after configurable period (default 2 years). Deletes attachments, replaces PII with `[ANONIMIZADO]`. Settings UI with enable/disable toggle and configurable retention days (30-3650).
- **CSV export PII masking**: Default CSV export masks cedulas (`****1234`). Separate "Exportar CSV completo" button with Ley 1581 confirmation dialog for unmasked export. Warning banner about personal data handling.
- **Privacy notice on form**: Ley 1581/2012 compliant privacy disclosure between Turnstile widget and submit button, explaining data collection, purpose, legal basis, retention policy, and citizen rights.

Bumps PQRRS plugin from 1.4.0 → 1.5.0.

## Test plan

- [ ] Activate plugin on fresh install — verify encryption key generated, cron scheduled
- [ ] Submit form — verify cedula stored encrypted in DB (`wp db query`)
- [ ] Admin modal — verify decrypted cedula displays correctly
- [ ] CSV export — default shows `****1234`, full export shows complete cedula after confirm dialog
- [ ] Deactivate/reactivate with no encryption key — verify graceful degradation + admin warning
- [ ] Retention cron — create old completed record, trigger `do_action('eeppj_pqrrs_retention_cron')`, verify anonymized
- [ ] Settings page — verify retention toggle and days input render and save correctly
- [ ] Privacy notice renders on `/pqrrs/` page with correct styling
- [ ] Upgrade path — existing install with plaintext cedulas gets them encrypted on admin_init
- [ ] `php -l` passes on all modified files (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)